### PR TITLE
--maxNameLength option fix

### DIFF
--- a/src/ch/ehi/ili2db/AbstractMain.java
+++ b/src/ch/ehi/ili2db/AbstractMain.java
@@ -246,6 +246,7 @@ public abstract class AbstractMain {
 				argi++;
 				config.setNameOptimization(config.NAME_OPTIMIZATION_TOPIC);
 			}else if(arg.equals("--maxNameLength")){
+				argi++;
 				config.setMaxSqlNameLength(args[argi]);
 				argi++;
 			}else if(arg.equals("--structWithGenericRef")){


### PR DESCRIPTION
Fix for --maxNameLength option. The index _argi_ was not correctly incremented.