### PR TITLE
Add ili2mssql

### DIFF
--- a/build-ili2mssql.xml
+++ b/build-ili2mssql.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project basedir="." default="jar" name="ili2mssql">
+
+  <!-- set global properties for this build -->
+  <property name="src" value="${basedir}/src"/>
+  <property name="build" value="${basedir}/build"/>
+  <property name="dist" value="${basedir}/dist"/>
+  <property name="lib" value="libs"/>
+  <property name="mssql" value="sqljdbc42.jar"/>
+  <property name="report.dir" value="${build}/junitreport"/>
+  <property name="junit.dir" value="${build}/junit"/>
+  <property name="junit-out.dir" value="${build}/junit/test-out"/>
+  <property file="user.properties" prefix="user."/>
+
+  <target name="init">
+    <!-- Create the time stamp -->
+    <tstamp/>
+    <property name="projectjar" value="${build}/jar/${ant.project.name}.jar"/>
+    <!-- Create the build directory structure used by compile -->
+    <mkdir dir="${build}"/>
+    <mkdir dir="${build}/jar"/>
+    <mkdir dir="${dist}"/>
+  </target>
+
+	<path id="classpath">
+		<pathelement location="${lib}/antlr.jar"/>
+		<pathelement location="${lib}/ehibasics.jar"/>
+		<pathelement location="${lib}/ili2c-core.jar"/>
+		<pathelement location="${lib}/ili2c-tool.jar"/>
+		<pathelement location="${lib}/iox-api.jar"/>
+		<pathelement location="${lib}/iox-ili.jar"/>
+		<pathelement location="${lib}/jts-core-1.14.0.jar"/>
+		<pathelement location="${lib}/gson-2.6.2.jar"/>
+		<pathelement location="${lib}/toml4j-0.5.1.jar"/>
+		<pathelement location="${lib}/ehisqlgen.jar"/>
+		<pathelement location="${lib}/${mssql}"/>
+	</path>
+	<path id="junit">
+		<pathelement location="${lib}/junit-4.11.jar"/>
+		<pathelement location="${lib}/hamcrest-core-1.3.jar"/>
+	</path>
+  
+  <target depends="init" name="compile">
+    <!-- Compile the java code from ${src} into ${build}/classes -->
+    <mkdir dir="${build}/classes"/>
+    <javac destdir="${build}/classes" includes="**/*.java" source="1.6" target="1.6">
+		<classpath>
+			<path refid="classpath"/>
+			<path refid="junit"/>
+		</classpath>
+		<src path="${src}" />
+		<src path="ili2mssql/src"/>
+    	<!-- <src path="ili2mssql/test/java"/> -->
+    </javac>
+  </target>
+
+
+  <target depends="init" name="javadocs">
+    <mkdir dir="${build}/javadoc/api"/>
+    <javadoc Public="true" Windowtitle="${ant.project.name}" destdir="${build}/javadoc/api">
+    	<sourcepath path="${src}"/>
+    </javadoc>
+  </target>
+
+
+  <target depends="init,compile" name="jar">
+    <propertyfile file="ili2mssql/src/ch/ehi/ili2mssql/Version.properties">
+	<!-- <entry  key="versionMicro" type="int" value="1" operation="+"/> -->
+	<entry  key="versionDate" type="date" value="now" pattern="yyyyMMdd"/>
+    </propertyfile>
+
+    <delete file="${projectjar}" quiet="true"/>
+
+    <jar jarfile="${projectjar}">
+	    <manifest>
+	      <attribute name="Main-Class" value="ch.ehi.ili2mssql.MsSqlMain"/>
+	      <attribute name="Class-Path" value="${lib}/antlr.jar ${lib}/ehibasics.jar ${lib}/gson-2.6.2.jar ${lib}/ili2c-core.jar ${lib}/ili2c-tool.jar ${lib}/iox-api.jar ${lib}/iox-ili.jar ${lib}/jts-core-1.14.0.jar ${lib}/toml4j-0.5.1.jar ${lib}/ehisqlgen.jar ${lib}/${mssql}"/>
+	    </manifest>
+	<fileset dir="${build}/classes" includes="**/*.class"/>
+    	<fileset dir="${src}" includes="**/*.properties"/>
+    	<fileset dir="ili2mssql/src" includes="**/*.properties"/>
+    	<!-- <fileset dir="resources/de" includes="**/*.properties"/>
+    	<fileset dir="resources/fr" includes="**/*.properties"/>
+	<fileset dir="resources/it" includes="**/*.properties"/> -->
+    	<fileset dir="${src}" includes="**/*.gif"/>
+    	<fileset dir="${src}" includes="**/*.jpg"/>
+    	<fileset dir="${src}" includes="**/*.png"/>
+    </jar>
+  </target>
+
+  <target depends="init,compile" name="fatjar">
+    <property file="ili2mssql/src/ch/ehi/ili2mssql/Version.properties" prefix="buildnr."/>
+	<property name="buildnr" value="${buildnr.versionMajor}.${buildnr.versionMinor}.${buildnr.versionMicro}"/>
+
+	<delete file="${build}/jar/${ant.project.name}-${buildnr}.jar" quiet="true"/>
+
+    <jar jarfile="${build}/jar/${ant.project.name}-${buildnr}.jar" basedir="${build}/classes">
+	    <manifest>
+	      <attribute name="Main-Class" value="ch.ehi.ili2mssql.MsSqlMain"/>
+	    </manifest>
+
+		<zipgroupfileset dir="libs">
+			<include name ="antlr.jar"/>
+			<include name ="ehibasics.jar"/>
+			<include name ="gson-2.6.2.jar"/>
+			<include name ="ili2c-core.jar"/>
+			<include name ="ili2c-tool.jar"/>
+			<include name ="iox-api.jar"/>
+			<include name ="iox-ili.jar"/>
+			<include name ="jts-core-1.14.0.jar"/>
+			<include name ="toml4j-0.5.1.jar"/>
+			<include name ="ehisqlgen.jar"/>
+			<include name ="${mssql}"/>
+		</zipgroupfileset>
+
+		<fileset dir="${src}" includes="**/*.properties"/>
+		<fileset dir="ili2mssql/src" includes="**/*.properties"/>
+    </jar>
+  </target>
+  
+  <target depends="init" name="buildnr">
+    <property file="ili2mssql/src/ch/ehi/ili2mssql/Version.properties" prefix="buildnr."/>
+    <property name="buildnr" value="${buildnr.versionMajor}.${buildnr.versionMinor}.${buildnr.versionMicro}"/>
+    <!-- <property name="buildnr" value="${DSTAMP}"/> -->
+  </target>
+
+  <target depends="init,buildnr" name="bindist">
+    <delete file="${dist}/${ant.project.name}-${buildnr}.zip" quiet="true"/>
+    <zip zipfile="${dist}/${ant.project.name}-${buildnr}.zip">
+    	<zipfileset dir="${build}/jar" prefix="${ant.project.name}-${buildnr}">
+	    	<patternset includes="${ant.project.name}.jar"/>
+    	</zipfileset>
+    	<zipfileset dir="${basedir}" prefix="${ant.project.name}-${buildnr}">
+		<patternset includes="${lib}/antlr.jar"/>
+		<patternset includes="${lib}/ehibasics.jar"/>
+		<patternset includes="${lib}/gson-2.6.2.jar"/>
+		<patternset includes="${lib}/ili2c-core.jar"/>
+		<patternset includes="${lib}/ili2c-tool.jar"/>
+		<patternset includes="${lib}/iox-api.jar"/>
+		<patternset includes="${lib}/iox-ili.jar"/>
+		<patternset includes="${lib}/jts-core-1.14.0.jar"/>
+		<patternset includes="${lib}/toml4j-0.5.1.jar"/>
+		<patternset includes="${lib}/ehisqlgen.jar"/>
+	    	<patternset includes="${lib}/${mssql}"/>
+    	</zipfileset>
+    	<zipfileset dir="." prefix="${ant.project.name}-${buildnr}">
+	    	<patternset includes="docs/ili2db.html"/>
+	</zipfileset>	    	
+    </zip>
+  </target>
+  <target depends="init,buildnr" name="srcdist">
+    <delete file="${dist}/${ant.project.name}-${buildnr}.src.zip" quiet="true"/>
+    <zip zipfile="${dist}/${ant.project.name}-${buildnr}.src.zip">
+    	<zipfileset dir="." prefix="${ant.project.name}-${buildnr}">
+	    	<patternset includes="build-ili2mssql.xml"/>
+	    	<patternset includes="sample/zpl/**"/>
+	    	<patternset includes="src/**" excludes="**/CVS/*;**/bak~/*"/>
+	    	<patternset includes="ili2mssql/src/**" excludes="**/CVS/*;**/bak~/*"/>
+		<patternset includes="resources/de/**/*.properties"/>
+		<patternset includes="resources/fr/**/*.properties"/>
+		<patternset includes="resources/it/**/*.properties"/>
+		<patternset includes="${lib}/antlr.jar"/>
+		<patternset includes="${lib}/ehibasics.jar"/>
+		<patternset includes="${lib}/gson-2.6.2.jar"/>
+		<patternset includes="${lib}/ili2c-core.jar"/>
+		<patternset includes="${lib}/ili2c-tool.jar"/>
+		<patternset includes="${lib}/iox-api.jar"/>
+		<patternset includes="${lib}/iox-ili.jar"/>
+		<patternset includes="${lib}/jts-core-1.14.0.jar"/>
+		<patternset includes="${lib}/toml4j-0.5.1.jar"/>
+		<patternset includes="${lib}/ehisqlgen.jar"/>
+	    	<patternset includes="${lib}/${mssql}"/>
+    	</zipfileset>
+    </zip>
+  </target>
+
+  <target depends="junit,junitreport" name="tests"/>
+  
+  <target name="junit">
+		<delete dir="${junit-out.dir}" quiet="true"/>
+		<delete dir="${junit.dir}" quiet="true"/>
+		<mkdir dir="${junit.dir}"/>
+		<mkdir dir="${junit-out.dir}"/>
+		<mkdir dir="${report.dir}"/>
+		<copy todir="${junit.dir}">
+			<fileset dir="${basedir}">
+				<include name="test/data/**/*"/>
+			</fileset>
+		</copy>
+		<junit printsummary="yes" dir="${junit.dir}">
+			<classpath>
+				<path refid="classpath"/>
+				<path refid="junit"/>
+				<pathelement location="${build}/classes"/>
+				<pathelement location="${src}" />
+				<pathelement location="ili2mssql/src"/>
+			</classpath>
+			
+			<formatter type="xml"/>
+
+			<batchtest fork="yes" todir="${report.dir}">
+				<fileset dir="ili2mssql/test/java" includes="**/*Test.java"/>
+			</batchtest>
+		</junit>
+	</target>
+
+	<target name="junitreport">
+		<junitreport todir="${report.dir}">
+			<fileset dir="${report.dir}" includes="TEST-*.xml"/>
+			<report todir="${report.dir}"/>
+		</junitreport>
+	</target>
+  
+  
+  <target name="clean">
+    <delete dir="${build}"/>
+  </target>
+
+</project>

--- a/ili2mssql/src/ch/ehi/ili2mssql/MsSqlCustomStrategy.java
+++ b/ili2mssql/src/ch/ehi/ili2mssql/MsSqlCustomStrategy.java
@@ -1,0 +1,52 @@
+package ch.ehi.ili2mssql;
+
+import java.sql.Connection;
+
+import ch.ehi.ili2db.base.AbstractJdbcMapping;
+import ch.ehi.ili2db.gui.Config;
+import ch.ehi.sqlgen.repository.DbColumn;
+import ch.ehi.sqlgen.repository.DbTable;
+import ch.ehi.sqlgen.repository.DbTableName;
+import ch.interlis.ili2c.metamodel.AssociationDef;
+import ch.interlis.ili2c.metamodel.AttributeDef;
+import ch.interlis.ili2c.metamodel.RoleDef;
+import ch.interlis.ili2c.metamodel.Viewable;
+
+public class MsSqlCustomStrategy  extends AbstractJdbcMapping {
+
+	@Override
+	public void fromIliInit(Config config) {
+		
+	}
+
+	@Override
+	public void fromIliEnd(Config config) {
+		
+	}
+
+	@Override
+	public void fixupViewable(DbTable sqlTableDef, Viewable iliClassDef) {
+		
+	}
+
+	@Override
+	public void fixupAttribute(DbTable sqlTableDef, DbColumn sqlColDef, AttributeDef iliAttrDef) {
+		
+	}
+
+	@Override
+	public void fixupEmbeddedLink(DbTable dbTable, DbColumn dbColId, AssociationDef roleOwner, RoleDef role,
+			DbTableName targetTable, String targetPk) {
+	}
+
+	@Override
+	public void preConnect(String url, String dbusr, String dbpwd, Config config) {
+		
+	}
+
+	@Override
+	public void postConnect(Connection conn, Config config) {
+		
+	}
+
+}

--- a/ili2mssql/src/ch/ehi/ili2mssql/MsSqlMain.java
+++ b/ili2mssql/src/ch/ehi/ili2mssql/MsSqlMain.java
@@ -1,0 +1,121 @@
+package ch.ehi.ili2mssql;
+
+import ch.ehi.ili2db.base.DbUrlConverter;
+import ch.ehi.ili2db.gui.AbstractDbPanelDescriptor;
+import ch.ehi.ili2db.gui.Config;
+
+
+public class MsSqlMain  extends ch.ehi.ili2db.AbstractMain {
+
+	String dbinstance = "";
+	boolean dbWindowsAuth = false;
+	
+	@Override
+	public void initConfig(Config config) {
+		super.initConfig(config);
+		config.setGeometryConverter(ch.ehi.ili2mssql.converter.MsSqlColumnConverter.class.getName());
+		config.setDdlGenerator(ch.ehi.ili2mssql.sqlgen.GeneratorMsSql.class.getName());
+		config.setJdbcDriver("com.microsoft.sqlserver.jdbc.SQLServerDriver");
+		config.setIdGenerator(ch.ehi.ili2mssql.MsSqlSequenceBasedIdGen.class.getName());
+		config.setIli2dbCustomStrategy(ch.ehi.ili2mssql.MsSqlCustomStrategy.class.getName());
+		config.setUuidDefaultValue("uuid_generate_v4()");
+	}
+	
+	@Override
+	protected DbUrlConverter getDbUrlConverter() {
+		return new DbUrlConverter(){
+			public String makeUrl(Config config) {
+				if(config.getDbdatabase()!=null){
+					
+					String strDbHost = config.getDbhost()!=null&&!config.getDbhost().isEmpty()? config.getDbhost():"localhost";
+					String strInstance = dbinstance.isEmpty()?"":"\\"+dbinstance;
+					String strPort = config.getDbport()!=null && !config.getDbport().isEmpty()?":"+config.getDbport():"";
+					String strDbdatabase = ";databaseName="+config.getDbdatabase();
+					String strWindowsAuth =  dbWindowsAuth?";integratedSecurity=true":"";
+					
+					return "jdbc:sqlserver://" + strDbHost + strInstance + strPort + strDbdatabase + strWindowsAuth;
+				}
+				return null;
+			}
+		};
+	}
+	
+	@Override
+	public AbstractDbPanelDescriptor getDbPanelDescriptor() {
+		return null;
+	}
+	
+	static public void main(String args[]){
+		new MsSqlMain().domain(args);
+	}
+	
+	@Override
+	public String getAPP_NAME() {
+		return "ili2mssql";
+	}
+
+	@Override
+	public String getDB_PRODUCT_NAME() {
+		return "SQL Server";
+	}
+
+	@Override
+	public String getJAR_NAME() {
+		return "ili2mssql.jar";
+	}
+
+	@Override
+	protected void printConnectOptions() {
+		System.err.println("--dbhost  host         The host name of the server. Defaults to localhost.");
+		System.err.println("--dbport  port         The port number the server is listening on. Defaults to 1433.");
+		System.err.println("--dbdatabase database  The database name.");
+		System.err.println("--dbusr  username      User name to access database.");
+		System.err.println("--dbpwd  password      Password of user used to access database.");
+	}
+	
+	@Override
+	protected void printSpecificOptions() {
+		System.err.println("--dbinstance instance  The instance of the Database Engine");
+		System.err.println("--dbschema  schema     The name of the schema in the database. Defaults to not set.");
+		System.err.println("--dbwindowsauth        SQL Server validates a user's identity using only his Windows username and password");
+	}
+
+	@Override
+	protected int doArgs(String args[],int argi,Config config)
+	{
+		String arg=args[argi];
+		if(arg.equals("--dbhost")){
+			argi++;
+			config.setDbhost(args[argi]);
+			argi++;
+		}else if(arg.equals("--dbport")){
+			argi++;
+			config.setDbport(args[argi]);
+			argi++;
+		}else if(arg.equals("--dbdatabase")){
+			argi++;
+			config.setDbdatabase(args[argi]);
+			argi++;
+		}else if(arg.equals("--dbusr")){
+			argi++;
+			config.setDbusr(args[argi]);
+			argi++;
+		}else if(arg.equals("--dbpwd")){
+			argi++;
+			config.setDbpwd(args[argi]);
+			argi++;
+		}else if(arg.equals("--dbschema")){
+			argi++;
+			config.setDbschema(args[argi]);
+			argi++;
+		}else if(arg.equals("--dbinstance")){
+			argi++;
+			dbinstance = args[argi];
+			argi++;
+		}else if(arg.equals("--dbwindowsauth")){
+			argi++;
+			dbWindowsAuth = true;
+		}
+		return argi;
+	}
+}

--- a/ili2mssql/src/ch/ehi/ili2mssql/MsSqlSequenceBasedIdGen.java
+++ b/ili2mssql/src/ch/ehi/ili2mssql/MsSqlSequenceBasedIdGen.java
@@ -1,0 +1,133 @@
+package ch.ehi.ili2mssql;
+
+import java.sql.Connection;
+
+import ch.ehi.basics.logging.EhiLogger;
+import ch.ehi.ili2db.base.DbIdGen;
+import ch.ehi.ili2db.gui.Config;
+import ch.ehi.sqlgen.generator.Generator;
+import ch.ehi.sqlgen.generator_impl.jdbc.GeneratorJdbc;
+import ch.ehi.sqlgen.repository.DbSchema;
+import ch.ehi.sqlgen.repository.DbTableName;
+
+public class MsSqlSequenceBasedIdGen implements DbIdGen {
+
+	public final static String SQL_ILI2DB_SEQ_NAME="t_ili2db_seq";
+	java.sql.Connection conn=null;
+	String dbusr=null;
+	String schema=null;
+	Long minValue=null;
+	Long maxValue=null;
+	
+	Long startWith;
+	
+	@Override
+	public void init(String schema, Config config) {
+		this.schema=schema;
+		minValue=config.getMinIdSeqValue();
+		maxValue=config.getMaxIdSeqValue();
+		
+		startWith = 1L;
+	}
+
+	@Override
+	public void initDb(Connection conn, String dbusr) {
+		this.conn=conn;
+		this.dbusr=dbusr;
+	}
+
+	@Override
+	public void initDbDefs(Generator gen) {
+		DbTableName sqlName=new DbTableName(schema,SQL_ILI2DB_SEQ_NAME);
+		String stmt="CREATE SEQUENCE "+sqlName.getQName()+ " START WITH "+startWith;
+		if(minValue!=null){
+			stmt=stmt+" MINVALUE "+minValue;
+		}
+		if(maxValue!=null){
+			stmt=stmt+" MAXVALUE "+maxValue;
+		}
+		stmt=stmt+";";
+		if(gen instanceof GeneratorJdbc){
+			((GeneratorJdbc) gen).addCreateLine(((GeneratorJdbc) gen).new Stmt(stmt));
+			((GeneratorJdbc) gen).addDropLine(((GeneratorJdbc) gen).new Stmt("DROP SEQUENCE "+sqlName.getQName()+";"));
+		}
+		
+		// Check if a sequence exists (PLSQL)
+		String seqExist = "IF NOT EXISTS(SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'"+sqlName.getQName()+"') AND type = 'SO')\r\n"+
+				"begin\r\n"+ stmt +"\r\nend";
+		
+		stmt = seqExist;
+		
+		EhiLogger.traceBackendCmd(stmt);
+		java.sql.PreparedStatement updstmt = null;
+		try{
+			updstmt = conn.prepareStatement(stmt);
+			updstmt.execute();
+		}catch(java.sql.SQLException ex){
+			EhiLogger.logError("failed to create sequence "+sqlName.getQName(),ex);
+		}finally{
+			if(updstmt!=null){
+				try{
+					updstmt.close();
+				}catch(java.sql.SQLException ex){
+					EhiLogger.logError(ex);
+				}
+			}
+		}
+	}
+	
+	long lastLocalId=0;
+	@Override
+	public long newObjSqlId(){
+		lastLocalId=getSeqCount();
+		return lastLocalId;
+	}
+	@Override
+	public long getLastSqlId()
+	{
+		return lastLocalId;
+	}
+	private long getSeqCount()
+	{
+		String sqlName=SQL_ILI2DB_SEQ_NAME;
+		if(schema!=null){
+			sqlName=schema+"."+sqlName;
+		}
+		java.sql.PreparedStatement getstmt=null;
+		try{
+			String stmt="SELECT next value for "+sqlName+"";
+			EhiLogger.traceBackendCmd(stmt);
+			getstmt=conn.prepareStatement(stmt);
+			java.sql.ResultSet res=getstmt.executeQuery();
+			long ret=0;
+			if(res.next()){
+				ret=res.getLong(1);
+				return ret;
+			}
+		}catch(java.sql.SQLException ex){
+			EhiLogger.logError("failed to query "+sqlName,ex);
+			throw new IllegalStateException(ex);
+		}finally{
+			if(getstmt!=null){
+				try{
+					getstmt.close();
+				}catch(java.sql.SQLException ex){
+					EhiLogger.logError(ex);
+				}
+			}
+		}
+		throw new IllegalStateException("no nextval "+sqlName);
+	}
+	@Override
+	public String getDefaultValueSql() {
+		String sqlName=SQL_ILI2DB_SEQ_NAME;
+		if(schema!=null){
+			sqlName=schema+"."+sqlName;
+		}
+		return "next value for "+sqlName+"";
+	}
+
+	@Override
+	public void addMappingTable(DbSchema schema) {
+	}
+}

--- a/ili2mssql/src/ch/ehi/ili2mssql/Version.properties
+++ b/ili2mssql/src/ch/ehi/ili2mssql/Version.properties
@@ -1,0 +1,4 @@
+versionMicro=0
+versionMinor=1
+versionDate=20170705
+versionMajor=0

--- a/ili2mssql/src/ch/ehi/ili2mssql/converter/MsSqlColumnConverter.java
+++ b/ili2mssql/src/ch/ehi/ili2mssql/converter/MsSqlColumnConverter.java
@@ -1,0 +1,56 @@
+package ch.ehi.ili2mssql.converter;
+
+import java.sql.Connection;
+
+import ch.ehi.ili2db.converter.AbstractWKBColumnConverter;
+import ch.ehi.ili2db.converter.ConverterException;
+import ch.ehi.iox.adddefval.Converter;
+
+public class MsSqlColumnConverter extends AbstractWKBColumnConverter {
+	final String defaultSrid = "3116";
+	
+	@Override
+	public String getInsertValueWrapperCoord(String wkfValue,int srid) {
+		return "geometry::STGeomFromWKB("+wkfValue+(srid==-1?","+defaultSrid:","+srid)+")";
+	}
+	@Override
+	public String getInsertValueWrapperPolyline(String wkfValue,int srid) {
+		return "geometry::STGeomFromWKB("+wkfValue+(srid==-1?","+defaultSrid:","+srid)+")";
+	}
+	@Override
+	public String getInsertValueWrapperSurface(String wkfValue,int srid) {
+		return "geometry::STGeomFromWKB("+wkfValue+(srid==-1?","+defaultSrid:","+srid)+")";
+	}
+	@Override
+	public String getInsertValueWrapperMultiSurface(String wkfValue,int srid) {
+		return "geometry::STGeomFromWKB("+wkfValue+(srid==-1?","+defaultSrid:","+srid)+")";
+	}
+	
+	@Override
+	public String getSelectValueWrapperCoord(String dbNativeValue) {
+		return dbNativeValue+".STAsBinary()";
+	}
+	@Override
+	public String getSelectValueWrapperPolyline(String dbNativeValue) {
+		return dbNativeValue+".STAsBinary()";
+	}
+	@Override
+	public String getSelectValueWrapperSurface(String dbNativeValue) {
+		return dbNativeValue+".STAsBinary()";
+	}
+	@Override
+	public String getSelectValueWrapperMultiSurface(String dbNativeValue) {
+		return dbNativeValue+".STAsBinary()";
+	}
+	
+	@Override
+	public Integer getSrsid(String crsAuthority, String crsCode,Connection conn) 
+		throws ConverterException{
+		
+		int srsid;
+		srsid=Integer.parseInt(crsCode);
+
+		return srsid;
+	}
+
+}

--- a/ili2mssql/src/ch/ehi/ili2mssql/sqlgen/GeneratorMsSql.java
+++ b/ili2mssql/src/ch/ehi/ili2mssql/sqlgen/GeneratorMsSql.java
@@ -1,0 +1,214 @@
+package ch.ehi.ili2mssql.sqlgen;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Iterator;
+
+import ch.ehi.basics.logging.EhiLogger;
+import ch.ehi.sqlgen.DbUtility;
+import ch.ehi.sqlgen.generator_impl.jdbc.GeneratorJdbc;
+import ch.ehi.sqlgen.repository.DbColBoolean;
+import ch.ehi.sqlgen.repository.DbColDate;
+import ch.ehi.sqlgen.repository.DbColDateTime;
+import ch.ehi.sqlgen.repository.DbColDecimal;
+import ch.ehi.sqlgen.repository.DbColGeometry;
+import ch.ehi.sqlgen.repository.DbColId;
+import ch.ehi.sqlgen.repository.DbColNumber;
+import ch.ehi.sqlgen.repository.DbColTime;
+import ch.ehi.sqlgen.repository.DbColUuid;
+import ch.ehi.sqlgen.repository.DbColVarchar;
+import ch.ehi.sqlgen.repository.DbColumn;
+import ch.ehi.sqlgen.repository.DbIndex;
+import ch.ehi.sqlgen.repository.DbTable;
+
+public class GeneratorMsSql extends GeneratorJdbc {
+	
+	@Override
+	public void visitColumn(DbTable dbTab,DbColumn column) throws IOException {
+		String type="";
+		
+		if(column instanceof DbColBoolean){
+			type="BIT";
+		}else if(column instanceof DbColDateTime){
+			type="DATETIME";
+		}else if(column instanceof DbColDate){
+			type="DATE";
+		}else if(column instanceof DbColTime){
+			type="TIME";
+		}else if(column instanceof DbColDecimal){
+			DbColDecimal col=(DbColDecimal)column;
+			type="DECIMAL("+Integer.toString(col.getSize())+","+Integer.toString(col.getPrecision())+")";
+		}else if(column instanceof DbColGeometry){
+			type="GEOMETRY";
+		}else if(column instanceof DbColId){
+			type="BIGINT";
+		}else if(column instanceof DbColUuid){
+			type="VARCHAR(36)";
+		}else if(column instanceof DbColNumber){
+			DbColNumber col=(DbColNumber)column;
+			type="NUMERIC("+Integer.toString(col.getSize())+")";
+		}else if(column instanceof DbColVarchar){
+			int colsize=((DbColVarchar)column).getSize();
+			if(colsize!=DbColVarchar.UNLIMITED)
+				type="VARCHAR("+Integer.toString(colsize)+")";
+			else
+				type="VARCHAR(MAX)";
+		}else{
+			type="VARCHAR(MAX)";
+		}
+		String isNull=column.isNotNull()?"NOT NULL":"NULL";
+		if(column.isPrimaryKey()){
+			isNull="PRIMARY KEY";
+		}
+		String sep=" ";
+		String defaultValue="";
+		if(column.getDefaultValue()!=null){
+			defaultValue=sep+"DEFAULT ("+column.getDefaultValue()+")";
+			sep=" ";
+		}
+		
+		String name=column.getName();
+		out.write(getIndent()+colSep+"["+name+"] "+type+" "+isNull+defaultValue+newline());
+		colSep=",";
+	}
+
+	
+	@Override
+	public void visit1TableEnd(DbTable tab) throws IOException {
+		super.visit1TableEnd(tab);
+	}
+	
+	@Override
+	public void visitTableEndColumn(DbTable tab) throws IOException {
+		boolean tableExists = DbUtility.tableExists(conn,tab.getName());
+	}
+	
+
+	@Override
+	public void visitTableBeginConstraint(DbTable dbTab) throws IOException {
+		super.visitTableBeginConstraint(dbTab);
+		
+		String sqlTabName=dbTab.getName().getQName();
+		for(Iterator dbColi=dbTab.iteratorColumn();dbColi.hasNext();){
+			DbColumn dbCol=(DbColumn) dbColi.next();
+			if(dbCol.getReferencedTable()!=null){
+				String createstmt=null;
+				String action="";
+				if(dbCol.getOnUpdateAction()!=null){
+					action=action+" ON UPDATE "+dbCol.getOnUpdateAction();
+				}
+				if(dbCol.getOnDeleteAction()!=null){
+					action=action+" ON DELETE "+dbCol.getOnDeleteAction();
+				}
+				String constraintName=createConstraintName(dbTab,"fkey",dbCol.getName());
+				
+				createstmt="ALTER TABLE "+sqlTabName+" ADD CONSTRAINT "+constraintName+" FOREIGN KEY ( "+dbCol.getName()+" ) REFERENCES "+dbCol.getReferencedTable().getQName();//+action+" DEFERRABLE INITIALLY DEFERRED";
+				
+				String dropstmt=null;
+				dropstmt="ALTER TABLE "+sqlTabName+" DROP CONSTRAINT "+constraintName;
+
+				addConstraint(dbTab, constraintName,createstmt, dropstmt);
+				
+			}
+			if(dbCol instanceof DbColNumber && (((DbColNumber)dbCol).getMinValue()!=null || ((DbColNumber)dbCol).getMaxValue()!=null)){
+				DbColNumber dbColNum=(DbColNumber)dbCol;
+				String createstmt=null;
+				String action="";
+				if(dbColNum.getMinValue()!=null || dbColNum.getMaxValue()!=null){
+					if(dbColNum.getMaxValue()==null){
+						action=">="+dbColNum.getMinValue();
+					}else if(dbColNum.getMinValue()==null){
+						action="<="+dbColNum.getMaxValue();
+					}else{
+						action="BETWEEN "+dbColNum.getMinValue()+" AND "+dbColNum.getMaxValue();
+					}
+				}
+				String constraintName=createConstraintName(dbTab,"check",dbCol.getName());
+
+				createstmt="ALTER TABLE "+sqlTabName+" ADD CONSTRAINT "+constraintName+" CHECK( "+dbCol.getName()+" "+action+")";
+				
+				String dropstmt=null;
+				dropstmt="ALTER TABLE "+sqlTabName+" DROP CONSTRAINT "+constraintName;
+
+				addConstraint(dbTab, constraintName,createstmt, dropstmt);
+				
+			} else if(dbCol instanceof DbColDecimal && (((DbColDecimal)dbCol).getMinValue()!=null || ((DbColDecimal)dbCol).getMaxValue()!=null)){
+				DbColDecimal dbColNum=(DbColDecimal)dbCol;
+				String createstmt=null;
+				String action="";
+				if(dbColNum.getMinValue()!=null || dbColNum.getMaxValue()!=null){
+					if(dbColNum.getMaxValue()==null){
+						action=">="+dbColNum.getMinValue();
+					}else if(dbColNum.getMinValue()==null){
+						action="<="+dbColNum.getMaxValue();
+					}else{
+						action="BETWEEN "+dbColNum.getMinValue()+" AND "+dbColNum.getMaxValue();
+					}
+				}
+				String constraintName=createConstraintName(dbTab,"check",dbCol.getName());
+				
+				createstmt="ALTER TABLE "+sqlTabName+" ADD CONSTRAINT "+constraintName+" CHECK( "+dbCol.getName()+" "+action+")";
+				
+				String dropstmt=null;
+				dropstmt="ALTER TABLE "+sqlTabName+" DROP CONSTRAINT "+constraintName;
+
+				addConstraint(dbTab, constraintName,createstmt, dropstmt);
+			}
+		}
+	}
+	
+	@Override
+	public void visitIndex(DbIndex idx) throws IOException {
+		if(idx.isUnique()){
+			java.io.StringWriter out = new java.io.StringWriter();
+			DbTable tab=idx.getTable();
+			String tableName=tab.getName().getQName();
+			String constraintName=idx.getName();
+			if(constraintName==null){
+				String colNames[]=new String[idx.sizeAttr()];
+				int i=0;
+				for(Iterator attri=idx.iteratorAttr();attri.hasNext();){
+					DbColumn attr=(DbColumn)attri.next();
+					colNames[i++]=attr.getName();
+				}
+				constraintName=createConstraintName(tab,"key", colNames);
+			}
+			out.write(getIndent()+"CREATE UNIQUE INDEX "+constraintName+" ON "+tableName+" (");
+			String sep="";
+			
+			String condition = " ";
+			String sepCondition = " ";
+			
+			for(Iterator attri=idx.iteratorAttr();attri.hasNext();){
+				DbColumn attr=(DbColumn)attri.next();
+				
+					out.write(sep+attr.getName());
+					condition += sepCondition + attr.getName() + " is not null";
+					
+				sep=",";
+				sepCondition = " AND ";
+			}
+			out.write(") WHERE"+condition+newline());
+			String stmt=out.toString();
+			addCreateLine(new Stmt(stmt));
+			out=null;
+			if(createdTables.contains(tab.getName())){
+				Statement dbstmt = null;
+				try{
+					try{
+						dbstmt = conn.createStatement();
+						EhiLogger.traceBackendCmd(stmt);
+						dbstmt.executeUpdate(stmt);
+					}finally{
+						dbstmt.close();
+					}
+				}catch(SQLException ex){
+					IOException iox=new IOException("failed to add UNIQUE to table "+tab.getName());
+					iox.initCause(ex);
+					throw iox;
+				}
+			}
+		}
+	}
+}

--- a/src/ch/ehi/ili2db/fromili/TransferFromIli.java
+++ b/src/ch/ehi/ili2db/fromili/TransferFromIli.java
@@ -418,7 +418,7 @@ public class TransferFromIli {
 				reposUri=reposUri+"/"+schema;
 			}
 			// select entries
-			String insStmt="SELECT "+DbNames.MODELS_TAB_FILE_COL+","+DbNames.MODELS_TAB_ILIVERSION_COL+","+DbNames.MODELS_TAB_MODELNAME_COL+" FROM "+sqlName;
+			String insStmt="SELECT \""+DbNames.MODELS_TAB_FILE_COL+"\","+DbNames.MODELS_TAB_ILIVERSION_COL+","+DbNames.MODELS_TAB_MODELNAME_COL+" FROM "+sqlName;
 			EhiLogger.traceBackendCmd(insStmt);
 			java.sql.PreparedStatement insPrepStmt = conn.prepareStatement(insStmt);
 			try{
@@ -451,7 +451,7 @@ public class TransferFromIli {
 		}
 		try{
 			// select entries
-			String selStmt="SELECT "+DbNames.MODELS_TAB_CONTENT_COL+" FROM "+sqlName+" WHERE "+DbNames.MODELS_TAB_FILE_COL+"=?";
+			String selStmt="SELECT "+DbNames.MODELS_TAB_CONTENT_COL+" FROM "+sqlName+" WHERE \""+DbNames.MODELS_TAB_FILE_COL+"\"=?";
 			EhiLogger.traceBackendCmd(selStmt);
 			java.sql.PreparedStatement selPrepStmt = conn.prepareStatement(selStmt);
 			try{
@@ -487,7 +487,7 @@ public class TransferFromIli {
 		try{
 
 			// insert entries
-			String insStmt="INSERT INTO "+sqlName+" ("+DbNames.MODELS_TAB_FILE_COL+","+DbNames.MODELS_TAB_ILIVERSION_COL+","+DbNames.MODELS_TAB_MODELNAME_COL+","+DbNames.MODELS_TAB_CONTENT_COL+","+DbNames.MODELS_TAB_IMPORTDATE_COL+") VALUES (?,?,?,?,?)";
+			String insStmt="INSERT INTO "+sqlName+" (\""+DbNames.MODELS_TAB_FILE_COL+"\","+DbNames.MODELS_TAB_ILIVERSION_COL+","+DbNames.MODELS_TAB_MODELNAME_COL+","+DbNames.MODELS_TAB_CONTENT_COL+","+DbNames.MODELS_TAB_IMPORTDATE_COL+") VALUES (?,?,?,?,?)";
 			EhiLogger.traceBackendCmd(insStmt);
 			java.sql.PreparedStatement insPrepStmt = conn.prepareStatement(insStmt);
 			java.util.Iterator entri=td.iterator();

--- a/src/ch/ehi/ili2db/fromili/TransferFromIli.java
+++ b/src/ch/ehi/ili2db/fromili/TransferFromIli.java
@@ -385,7 +385,7 @@ public class TransferFromIli {
 		DbColVarchar importsCol=new DbColVarchar();
 		importsCol.setName(DbNames.MODELS_TAB_MODELNAME_COL);
 		importsCol.setNotNull(true);
-		importsCol.setSize(DbColVarchar.UNLIMITED);
+		importsCol.setSize(400);
 		tab.addColumn(importsCol);
 		DbColVarchar contentCol=new DbColVarchar();
 		contentCol.setName(DbNames.MODELS_TAB_CONTENT_COL);


### PR DESCRIPTION
Add tool ili2mssql to support Microsoft Sql Server version >= 2012. 

New implemetations for ili2mssql:
- [x] MsSqlMain (AbstractMain)
- [x] MsSqlColumnConverter (Column converter)
- [x] GeneratorMsSql (GeneratorJdbc)
- [x] MsSqlSequenceBasedIdGen (DbIdGen)
- [x] MsSqlCustomStrategy (Custom strategy)

The only modified file from ili2db was `TransferFromIli.java`:
- Enclosed 'file' column with double quotes because 'file' is keyword in Sql server
- Changed column size T_ILI2DB_MODEL(modelName): DbColVarchar.UNLIMITED to 400 because 'SQL Server retains the 900-byte limit for the maximum total size of all index key columns'