### PR TITLE
Fix Issue #206

### DIFF
--- a/ili2mssql/src/ch/ehi/ili2mssql/MsSqlCustomStrategy.java
+++ b/ili2mssql/src/ch/ehi/ili2mssql/MsSqlCustomStrategy.java
@@ -110,4 +110,10 @@ public class MsSqlCustomStrategy  extends AbstractJdbcMapping {
 			}
 		}
 	}
+	
+	@Override
+	public String shortenConnectUrl4IliCache(String url) {
+		String[] parts = url.split(";");
+		return parts[0]; //the first part contains host, port and instance
+	}
 }


### PR DESCRIPTION
Implemented shortenConnectUrl4IliCache in ili2mssql: remained host, port and instance and removed connection properties.
