### PR TITLE
ili2ora: fixed fromIom* methods that failed when input geometry contained a lot of data

### DIFF
--- a/ili2ora/src/ch/ehi/ili2ora/OracleCustomStrategy.java
+++ b/ili2ora/src/ch/ehi/ili2ora/OracleCustomStrategy.java
@@ -1,7 +1,9 @@
 package ch.ehi.ili2ora;
 
 import java.sql.Connection;
-
+import java.sql.SQLException;
+import java.sql.Statement;
+import ch.ehi.basics.logging.EhiLogger;
 import ch.ehi.ili2db.base.AbstractJdbcMapping;
 import ch.ehi.ili2db.gui.Config;
 import ch.ehi.sqlgen.repository.DbColumn;
@@ -11,50 +13,88 @@ import ch.interlis.ili2c.metamodel.AssociationDef;
 import ch.interlis.ili2c.metamodel.AttributeDef;
 import ch.interlis.ili2c.metamodel.RoleDef;
 import ch.interlis.ili2c.metamodel.Viewable;
+import ch.ehi.sqlgen.generator.TextFileUtility;
 
 public class OracleCustomStrategy extends AbstractJdbcMapping {
-
+    private final String wrapperFunction = "ILI2ORA_SDO_GEOMETRY";
+    private Connection conn = null;
+    
 	@Override
 	public void fromIliInit(Config config) {
-		// TODO Auto-generated method stub
-		
-	}
+        String schema = config.getDbschema();
+        String strWrapperFunction = wrapperFunction;
+        TextFileUtility txtOut=new TextFileUtility();
+
+        if(schema != null && !schema.isEmpty()) {
+            strWrapperFunction = schema + "." + strWrapperFunction;
+        }
+        
+        String stmt = "";
+        
+        stmt += txtOut.getIndent() + "CREATE OR REPLACE FUNCTION " + strWrapperFunction;
+        stmt += "(geom_input BLOB, srid NUMBER)" + txtOut.newline();
+        txtOut.inc_ind();
+        stmt += txtOut.getIndent() + "RETURN MDSYS.SDO_GEOMETRY IS geom MDSYS.SDO_GEOMETRY;" + txtOut.newline();
+        txtOut.dec_ind();
+        stmt += txtOut.getIndent() + "BEGIN" + txtOut.newline();
+        txtOut.inc_ind();
+        stmt += txtOut.getIndent() + "geom := NULL;" + txtOut.newline();
+        stmt += txtOut.getIndent() + "IF geom_input IS NOT NULL THEN" + txtOut.newline();
+        txtOut.inc_ind();
+        stmt += txtOut.getIndent() + "geom := SDO_GEOMETRY(geom_input, srid);" + txtOut.newline();
+        txtOut.dec_ind();
+        stmt += txtOut.getIndent() + "END IF;" + txtOut.newline();
+        stmt += txtOut.getIndent() + "RETURN(geom);" + txtOut.newline();
+        txtOut.dec_ind();
+        stmt += txtOut.getIndent() + "END;";
+        
+        Statement dbstmt = null;
+        if(conn != null) {
+            try{
+                try{
+                    dbstmt = conn.createStatement();
+                    EhiLogger.traceBackendCmd(stmt);
+                    dbstmt.execute(stmt);
+                }catch(SQLException e){
+                    throw new IllegalStateException("failed to add function " + strWrapperFunction);
+                }
+            }finally{
+                if(dbstmt!=null){
+                    try {
+                        dbstmt.close();
+                        dbstmt=null;
+                    } catch (SQLException e) {
+                        EhiLogger.logError(e);
+                    }
+                }
+            }
+        }
+    }
 
 	@Override
 	public void fromIliEnd(Config config) {
-		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
 	public void fixupViewable(DbTable sqlTableDef, Viewable iliClassDef) {
-		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
 	public void fixupAttribute(DbTable sqlTableDef, DbColumn sqlColDef, AttributeDef iliAttrDef) {
-		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
 	public void fixupEmbeddedLink(DbTable dbTable, DbColumn dbColId, AssociationDef roleOwner, RoleDef role,
 			DbTableName targetTable, String targetPk) {
-		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
 	public void preConnect(String url, String dbusr, String dbpwd, Config config) {
-		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
 	public void postConnect(Connection conn, Config config) {
-		// TODO Auto-generated method stub
-		
+		this.conn = conn;
 	}
 
 }

--- a/ili2ora/src/ch/ehi/ili2ora/converter/OracleSpatialColumnConverter.java
+++ b/ili2ora/src/ch/ehi/ili2ora/converter/OracleSpatialColumnConverter.java
@@ -1,5 +1,7 @@
 package ch.ehi.ili2ora.converter;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.sql.Blob;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -14,14 +16,14 @@ import ch.interlis.iox_j.wkb.Iox2wkbException;
 import ch.interlis.iox_j.wkb.Wkb2iox;
 
 public class OracleSpatialColumnConverter extends AbstractWKBColumnConverter {
-	
-	private boolean strokeArcs=true;
-	
-	@Override
-	public void setup(Connection conn, Settings config) {
-		super.setup(conn,config);
-		strokeArcs=Config.STROKE_ARCS_ENABLE.equals(Config.getStrokeArcs(config));
-	}
+    
+    private boolean strokeArcs=true;
+    
+    @Override
+    public void setup(Connection conn, Settings config) {
+        super.setup(conn,config);
+        strokeArcs=Config.STROKE_ARCS_ENABLE.equals(Config.getStrokeArcs(config));
+    }
 
     @Override
     public String getInsertValueWrapperCoord(String wkfValue,int srid) {
@@ -44,26 +46,33 @@ public class OracleSpatialColumnConverter extends AbstractWKBColumnConverter {
         return "ILI2ORA_SDO_GEOMETRY(" + wkfValue + ", "+ Integer.toString(srid)  + ")";
     }
     @Override
+    public String getInsertValueWrapperMultiCoord(String wkfValue,int srid) {
+        return "ILI2ORA_SDO_GEOMETRY(" + wkfValue + ", "+ Integer.toString(srid)  + ")";
+    }
+    @Override
     public String getSelectValueWrapperCoord(String dbNativeValue) {
         return "SDO_UTIL.TO_WKBGEOMETRY(" + dbNativeValue + ")";
     }
-	@Override
-	public String getSelectValueWrapperPolyline(String dbNativeValue) {
-		return "SDO_UTIL.TO_WKBGEOMETRY(" + dbNativeValue + ")";
-	}
-	@Override
-	public String getSelectValueWrapperSurface(String dbNativeValue) {
-		return "SDO_UTIL.TO_WKBGEOMETRY(" + dbNativeValue + ")";
-	}
-	@Override
-	public String getSelectValueWrapperMultiSurface(String dbNativeValue) {
-		return "SDO_UTIL.TO_WKBGEOMETRY(" + dbNativeValue + ")";
-	}
+    @Override
+    public String getSelectValueWrapperPolyline(String dbNativeValue) {
+        return "SDO_UTIL.TO_WKBGEOMETRY(" + dbNativeValue + ")";
+    }
+    @Override
+    public String getSelectValueWrapperSurface(String dbNativeValue) {
+        return "SDO_UTIL.TO_WKBGEOMETRY(" + dbNativeValue + ")";
+    }
+    @Override
+    public String getSelectValueWrapperMultiSurface(String dbNativeValue) {
+        return "SDO_UTIL.TO_WKBGEOMETRY(" + dbNativeValue + ")";
+    }
     @Override
     public String getSelectValueWrapperMultiPolyline(String dbNativeValue) {
         return "SDO_UTIL.TO_WKBGEOMETRY(" + dbNativeValue + ")";
     }
-
+    @Override
+    public String getSelectValueWrapperMultiCoord(String dbNativeValue) {
+        return "SDO_UTIL.TO_WKBGEOMETRY(" + dbNativeValue + ")";
+    }
     @Override
     public java.lang.Object fromIomSurface(
         IomObject value,
@@ -75,8 +84,18 @@ public class OracleSpatialColumnConverter extends AbstractWKBColumnConverter {
             Iox2wkb conv=new Iox2wkb(is3D?3:2);
 
             try {
-                return conv.surface2wkb(value,!strokeArcs,p);
+                byte[] geomObj = conv.surface2wkb(value,!strokeArcs,p);
+                
+                Blob data = conn.createBlob();
+                OutputStream stream =  data.setBinaryStream(1);
+                
+                stream.write((byte[])geomObj);
+                stream.flush();
+                
+                return data;
             } catch (Iox2wkbException ex) {
+                throw new ConverterException(ex);
+            } catch (IOException ex) {
                 throw new ConverterException(ex);
             }
         }
@@ -93,8 +112,18 @@ public class OracleSpatialColumnConverter extends AbstractWKBColumnConverter {
             Iox2wkb conv=new Iox2wkb(is3D?3:2);
 
             try {
-                return conv.multisurface2wkb(value,!strokeArcs,p);
+                byte[] geomObj =conv.multisurface2wkb(value,!strokeArcs,p);
+                
+                Blob data = conn.createBlob();
+                OutputStream stream =  data.setBinaryStream(1);
+                
+                stream.write((byte[])geomObj);
+                stream.flush();
+                
+                return data;
             } catch (Iox2wkbException ex) {
+                throw new ConverterException(ex);
+            } catch (IOException ex) {
                 throw new ConverterException(ex);
             }
         }
@@ -106,8 +135,18 @@ public class OracleSpatialColumnConverter extends AbstractWKBColumnConverter {
         if (value!=null) {
             Iox2wkb conv=new Iox2wkb(is3D?3:2);
             try {
-                return conv.coord2wkb(value);
+                byte[] geomObj =  conv.coord2wkb(value);
+                
+                Blob data = conn.createBlob();
+                OutputStream stream =  data.setBinaryStream(1);
+                
+                stream.write((byte[])geomObj);
+                stream.flush();
+                
+                return data;
             } catch (Iox2wkbException ex) {
+                throw new ConverterException(ex);
+            } catch (IOException ex) {
                 throw new ConverterException(ex);
             }
         }
@@ -119,8 +158,18 @@ public class OracleSpatialColumnConverter extends AbstractWKBColumnConverter {
         if (value!=null) {
             Iox2wkb conv=new Iox2wkb(is3D?3:2);
             try {
-                return conv.multicoord2wkb(value);
+                byte[] geomObj = conv.multicoord2wkb(value);
+                
+                Blob data = conn.createBlob();
+                OutputStream stream =  data.setBinaryStream(1);
+             
+                stream.write((byte[])geomObj);
+                stream.flush();
+                
+                return data;
             } catch (Iox2wkbException ex) {
+                throw new ConverterException(ex);
+            } catch (IOException ex) {
                 throw new ConverterException(ex);
             }
         }
@@ -132,8 +181,19 @@ public class OracleSpatialColumnConverter extends AbstractWKBColumnConverter {
         if (value!=null) {
             Iox2wkb conv=new Iox2wkb(is3D?3:2);
             try {
-                return conv.polyline2wkb(value,false,!strokeArcs,p);
+                byte[] geomObj =  conv.polyline2wkb(value,false,!strokeArcs,p);
+                
+                Blob data = conn.createBlob();
+                OutputStream stream =  data.setBinaryStream(1);
+             
+                stream.write((byte[])geomObj);
+                stream.flush();
+                
+                return data;
+                
             } catch (Iox2wkbException ex) {
+                throw new ConverterException(ex);
+            } catch (IOException ex) {
                 throw new ConverterException(ex);
             }
         }
@@ -145,8 +205,18 @@ public class OracleSpatialColumnConverter extends AbstractWKBColumnConverter {
         if (value!=null) {
             Iox2wkb conv=new Iox2wkb(is3D?3:2);
             try {
-                return conv.multiline2wkb(value,!strokeArcs,p);
+                byte[] geomObj =  conv.multiline2wkb(value,!strokeArcs,p);
+                
+                Blob data = conn.createBlob();
+                OutputStream stream =  data.setBinaryStream(1);
+             
+                stream.write((byte[])geomObj);
+                stream.flush();
+                
+                return data;
             } catch (Iox2wkbException ex) {
+                throw new ConverterException(ex);
+            } catch (IOException ex) {
                 throw new ConverterException(ex);
             }
         }
@@ -256,13 +326,13 @@ public class OracleSpatialColumnConverter extends AbstractWKBColumnConverter {
         }
     }
 
-	@Override
-	public Integer getSrsid(String crsAuthority, String crsCode,Connection conn) 
-	throws ConverterException
-	{
-		int srsid;
-		srsid=Integer.parseInt(crsCode);
+    @Override
+    public Integer getSrsid(String crsAuthority, String crsCode,Connection conn) 
+    throws ConverterException
+    {
+        int srsid;
+        srsid=Integer.parseInt(crsCode);
 
-		return srsid;
-	}
+        return srsid;
+    }
 }

--- a/ili2ora/src/ch/ehi/ili2ora/sqlgen/GeneratorOracleSpatial.java
+++ b/ili2ora/src/ch/ehi/ili2ora/sqlgen/GeneratorOracleSpatial.java
@@ -23,8 +23,7 @@ import ch.ehi.sqlgen.repository.DbSchema;
 import ch.ehi.sqlgen.repository.DbTable;
 
 public class GeneratorOracleSpatial extends GeneratorJdbc {
-    private final String wrapperFunction = "ILI2ORA_SDO_GEOMETRY";
-    
+
 	@Override
 	public void visitColumn(DbTable dbTab,DbColumn column) throws IOException {
 		String type="";
@@ -77,52 +76,6 @@ public class GeneratorOracleSpatial extends GeneratorJdbc {
 		out.write(getIndent()+colSep+name+" "+type+" "+isNull+newline());
 		colSep=",";
 	}
-
-    @Override
-    public void visitSchemaBegin(Settings config, DbSchema schema) throws IOException {
-        super.visitSchemaBegin(config, schema);
-        
-        String strWrapperFunction = wrapperFunction;
-        
-        if(schema != null && schema.getName() != null && !schema.getName().isEmpty()) {
-            strWrapperFunction = schema.getName() + "." + strWrapperFunction;
-        }
-        
-        String stmt = "";
-        
-        stmt += getIndent() + "CREATE OR REPLACE FUNCTION " + strWrapperFunction + "(geom_input BLOB, srid NUMBER)" + newline();
-        inc_ind();
-        stmt += getIndent() + "RETURN MDSYS.SDO_GEOMETRY IS geom MDSYS.SDO_GEOMETRY;" + newline(); 
-        dec_ind();
-        stmt += getIndent() + "BEGIN" + newline();
-        inc_ind();
-        stmt += getIndent() + "geom := NULL;" + newline(); 
-        stmt += getIndent() + "IF geom_input IS NOT NULL THEN" + newline();
-        inc_ind();
-        stmt += getIndent() + "geom := SDO_GEOMETRY(geom_input, srid);" + newline(); 
-        dec_ind();
-        stmt += getIndent() + "END IF;" + newline();
-        stmt += getIndent() + "RETURN(geom);" + newline();
-        dec_ind();
-        stmt += getIndent() + "END;";
-        
-        addCreateLine(new Stmt(stmt));
-        addDropLine(new Stmt("DROP FUNCTION " + strWrapperFunction));
-        Statement dbstmt = null;
-        try{
-            try{
-                dbstmt = conn.createStatement();
-                EhiLogger.traceBackendCmd(stmt);
-                dbstmt.execute(stmt);
-            }finally{
-                dbstmt.close();
-            }
-        }catch(SQLException ex){
-            IOException iox=new IOException("failed to add function " + strWrapperFunction);
-            iox.initCause(ex);
-            throw iox;
-        }
-    }
 
 	@Override
 	public void visitIndex(DbIndex idx) throws IOException {


### PR DESCRIPTION
When input geometry contained many bytes, Oracle threw error below:
- ORA-01461: can bind a LONG value only for insert into a LONG column

To avoid this, added conversion from byte[] to BLOB