### PR TITLE
Fixed duplicated geometry fields mapping for smart2inheritance (#296)

### DIFF
--- a/ili2pg/test/java/ch/ehi/ili2db/ExtendedGeomAttributesTest.java
+++ b/ili2pg/test/java/ch/ehi/ili2db/ExtendedGeomAttributesTest.java
@@ -1,0 +1,204 @@
+package ch.ehi.ili2db;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import ch.ehi.ili2db.base.Ili2db;
+import ch.ehi.ili2db.gui.Config;
+
+public class ExtendedGeomAttributesTest {
+	
+	protected static final String TEST_OUT="test/data/ExtendedAttributes/";
+	private static final String DBSCHEMA = "ExtendedGeomAttributesTest";
+	private static final String DBSCHEMA_ONE_GEOM = "ExtendedGeomAttributesTest_OneGeom";
+	private static final String DATASETNAME = "Testset1";
+
+	String dburl=System.getProperty("dburl"); 
+	String dbuser=System.getProperty("dbusr");
+	String dbpwd=System.getProperty("dbpwd");
+
+	public Config initConfig(String xtfFilename,String dbschema,String logfile) {
+		Config config=new Config();
+		new ch.ehi.ili2pg.PgMain().initConfig(config);
+		config.setDburl(dburl);
+		config.setDbusr(dbuser);
+		config.setDbpwd(dbpwd);
+		if(dbschema!=null){
+			config.setDbschema(dbschema);
+		}
+		if(logfile!=null){
+			config.setLogfile(logfile);
+		}
+		config.setXtffile(xtfFilename);
+		if(Ili2db.isItfFilename(xtfFilename)){
+			config.setItfTransferfile(true);
+		}
+		return config;
+	}
+	
+	
+	@Test
+	public void importIli() throws Exception{
+		
+		Connection jdbcConnection=null;
+		try{
+            Class driverClass = Class.forName("org.postgresql.Driver");
+            jdbcConnection = DriverManager.getConnection(dburl, dbuser, dbpwd);
+            Statement stmt=jdbcConnection.createStatement();
+	        stmt.execute("DROP SCHEMA IF EXISTS "+DBSCHEMA+" CASCADE");
+	        {
+	        	File data=new File(TEST_OUT,"ExtendedAttributes.ili");
+	        	Config config=initConfig(data.getPath(),DBSCHEMA,data.getPath()+".log");
+	        	config.setFunction(Config.FC_SCHEMAIMPORT);
+	        	config.setInheritanceTrafo(Config.INHERITANCE_TRAFO_SMART2);
+	        	config.setCreateFk(config.CREATE_FK_YES);
+	        	config.setDefaultSrsCode("3116");
+	        	Ili2db.readSettingsFromDb(config);
+				Ili2db.run(config,null);
+				//Checks correct tables and columns creation
+				{//parent class
+					String stmtTxt="SELECT column_name FROM information_schema.columns WHERE table_schema ='"+DBSCHEMA.toLowerCase()+"' AND table_name = 'firstlevelclass'";
+					Assert.assertTrue(stmt.execute(stmtTxt));
+					ResultSet rs=stmt.getResultSet();
+					List<String> found_column_names = new ArrayList<String>();
+					List<String> expected_column_names = new ArrayList<String>();
+					expected_column_names.add("t_id");
+					expected_column_names.add("my_geometry");
+					expected_column_names.add("my_another_geometry");
+					
+					while(rs.next()) {
+						found_column_names.add(rs.getString(1));
+					}
+					assertEquals(3, found_column_names.size());
+					for(String column : found_column_names) {
+						assertTrue(expected_column_names.contains(column));
+					}
+				}
+				{//child class
+					String stmtTxt="SELECT column_name FROM information_schema.columns WHERE table_schema ='"+DBSCHEMA.toLowerCase()+"' AND table_name = 'secondlevelclass'";
+					Assert.assertTrue(stmt.execute(stmtTxt));
+					ResultSet rs=stmt.getResultSet();
+					List<String> found_column_names = new ArrayList<String>();
+					List<String> expected_column_names = new ArrayList<String>();
+					expected_column_names.add("t_id");
+					expected_column_names.add("my_geometry");
+					expected_column_names.add("my_another_geometry");
+					
+					while(rs.next()) {
+						found_column_names.add(rs.getString(1));
+					}
+					assertEquals(3, found_column_names.size());
+					for(String column : found_column_names) {
+						assertTrue(expected_column_names.contains(column));
+					}
+				}
+				//Checks of correct attributes cardinalities
+				{//optional attribute
+					String stmtTxt = "SELECT attnotnull FROM pg_attribute where attrelid='"+DBSCHEMA.toLowerCase()+".\"firstlevelclass\"'::regclass AND attname='my_geometry'";
+					Assert.assertTrue(stmt.execute(stmtTxt));
+					ResultSet rs=stmt.getResultSet();
+					Assert.assertTrue(rs.next());
+					Assert.assertFalse(rs.getBoolean(1));
+				}
+				
+				{//optional attribute
+					String stmtTxt = "SELECT attnotnull FROM pg_attribute where attrelid='"+DBSCHEMA.toLowerCase()+".\"firstlevelclass\"'::regclass AND attname='my_another_geometry'";
+					Assert.assertTrue(stmt.execute(stmtTxt));
+					ResultSet rs=stmt.getResultSet();
+					Assert.assertTrue(rs.next());
+					Assert.assertFalse(rs.getBoolean(1));
+				}
+				{//override attribute from firstlevelclass, so cardinality must be mandatory
+					String stmtTxt = "SELECT attnotnull FROM pg_attribute where attrelid='"+DBSCHEMA.toLowerCase()+".\"secondlevelclass\"'::regclass AND attname='my_geometry'";
+					Assert.assertTrue(stmt.execute(stmtTxt));
+					ResultSet rs=stmt.getResultSet();
+					Assert.assertTrue(rs.next());
+					Assert.assertTrue(rs.getBoolean(1));
+				}
+				{//NOT override attribute from firstlevelclass, so cardinality must be optional
+					String stmtTxt = "SELECT attnotnull FROM pg_attribute where attrelid='"+DBSCHEMA.toLowerCase()+".\"secondlevelclass\"'::regclass AND attname='my_another_geometry'";
+					Assert.assertTrue(stmt.execute(stmtTxt));
+					ResultSet rs=stmt.getResultSet();
+					Assert.assertTrue(rs.next());
+					Assert.assertFalse(rs.getBoolean(1));
+				}
+				
+	        }
+		}finally{
+            if(jdbcConnection!=null){
+                jdbcConnection.close();
+            }
+        }   
+		
+	}
+	
+	@Test
+	public void importIliWithOneGeom() throws Exception{
+		
+		Connection jdbcConnection=null;
+		try{
+            Class driverClass = Class.forName("org.postgresql.Driver");
+            jdbcConnection = DriverManager.getConnection(dburl, dbuser, dbpwd);
+            Statement stmt=jdbcConnection.createStatement();
+	        stmt.execute("DROP SCHEMA IF EXISTS "+DBSCHEMA_ONE_GEOM+" CASCADE");
+	        {
+	        	File data=new File(TEST_OUT,"ExtendedAttributes.ili");
+	        	Config config=initConfig(data.getPath(),DBSCHEMA_ONE_GEOM,data.getPath()+".log");	
+	        	config.setFunction(Config.FC_SCHEMAIMPORT);
+	        	config.setInheritanceTrafo(Config.INHERITANCE_TRAFO_SMART2);
+	        	config.setCreateFk(config.CREATE_FK_YES);
+	        	config.setDefaultSrsCode("3116");
+	        	config.setOneGeomPerTable(true);
+	        	Ili2db.readSettingsFromDb(config);
+				Ili2db.run(config,null);
+	        }
+	      //Check correct tables creation
+			{//check tables quantity (must be 4: 2 for firstlevelclass and 2 for secondlevelclass)
+				String stmtTxt="SELECT table_name FROM information_schema.tables WHERE table_schema ='"+DBSCHEMA_ONE_GEOM.toLowerCase()+"' AND (table_name LIKE 'firstlevelclass%' OR table_name LIKE 'secondlevelclass%')";
+				Assert.assertTrue(stmt.execute(stmtTxt));
+				ResultSet rs=stmt.getResultSet();
+				List<String> found_table_names = new ArrayList<String>();
+				while(rs.next()) {					
+					found_table_names.add(rs.getString(1));
+				}
+				Assert.assertEquals(4, found_table_names.size());
+			}
+			{//check if a column is duplicated into several firstlevelclass tables
+				String stmtTxt="SELECT column_name, count(column_name) FROM information_schema.columns WHERE table_schema ='"+DBSCHEMA_ONE_GEOM.toLowerCase()+"' AND table_name LIKE 'firstlevelclass%' AND column_name <> 't_id' GROUP BY column_name";
+				Assert.assertTrue(stmt.execute(stmtTxt));
+				ResultSet rs=stmt.getResultSet();
+				
+				while(rs.next()) {
+					Assert.assertEquals(1, rs.getInt(2));
+				}
+			}
+			{//check if a column is duplicated into several secondlevelclass tables
+				String stmtTxt="SELECT column_name, count(column_name) FROM information_schema.columns WHERE table_schema ='"+DBSCHEMA_ONE_GEOM.toLowerCase()+"' AND table_name LIKE 'secondlevelclass%' AND column_name <> 't_id' GROUP BY column_name";
+				Assert.assertTrue(stmt.execute(stmtTxt));
+				ResultSet rs=stmt.getResultSet();
+				
+				while(rs.next()) {
+					Assert.assertEquals(1, rs.getInt(2));
+				}
+			}
+		}finally{
+            if(jdbcConnection!=null){
+                jdbcConnection.close();
+            }
+        }   
+		
+	}
+
+}

--- a/src/ch/ehi/ili2db/mapping/Viewable2TableMapper.java
+++ b/src/ch/ehi/ili2db/mapping/Viewable2TableMapper.java
@@ -330,6 +330,23 @@ public class Viewable2TableMapper {
 				attr=getBaseAttr(iliclass,attr); // get the most general attribute definition, but only up to the class of the current table
 				viewableTransferElement.obj=attr;
 				for(Integer epsgCode:getEpsgCodes(attr)) {
+                    // Make sure than an attribute has been mapped one single time
+                    boolean breakloop = false; 
+                    if(Config.INHERITANCE_TRAFO_SMART2.equals(config.getInheritanceTrafo())){
+                        if(attr.getExtensions().size()>1) {
+                            Set<AttributeDef> extensions = attr.getExtensions();
+                            extensions.remove(attr);
+                            
+                            for(AttributeDef attrDef : extensions) {
+                                if(attrDef.getBeanContext().equals(iliclass)) {
+                                    breakloop = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if(breakloop)
+                        continue;
 	                String sqlname=trafoConfig.getAttrConfig(iliclass,attr, epsgCode,TrafoConfigNames.SECONDARY_TABLE);
 	                if(sqlname==null) {
 	                    // pre ili2db 3.13.x

--- a/src/ch/ehi/ili2db/mapping/Viewable2TableMapper.java
+++ b/src/ch/ehi/ili2db/mapping/Viewable2TableMapper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.HashSet;
 
 import ch.ehi.basics.logging.EhiLogger;
 import ch.ehi.ili2db.base.Ili2cUtility;
@@ -334,11 +335,11 @@ public class Viewable2TableMapper {
                     boolean breakloop = false; 
                     if(Config.INHERITANCE_TRAFO_SMART2.equals(config.getInheritanceTrafo())){
                         if(attr.getExtensions().size()>1) {
-                            Set<AttributeDef> extensions = attr.getExtensions();
+                            Set<AttributeDef> extensions = new HashSet<AttributeDef>(attr.getExtensions());
                             extensions.remove(attr);
                             
                             for(AttributeDef attrDef : extensions) {
-                                if(attrDef.getBeanContext().equals(iliclass)) {
+                                if(attrDef.getBeanContext().equals(iliclass)) {//Checks if attr belongs to a parent class of the class that is being mapped
                                     breakloop = true;
                                     break;
                                 }

--- a/test/data/ExtendedAttributes/ExtendedAttributes.ili
+++ b/test/data/ExtendedAttributes/ExtendedAttributes.ili
@@ -1,0 +1,25 @@
+INTERLIS 2.3;
+
+MODEL Model (en_US)
+AT "mailto:omartellezf@gmail.com"
+VERSION "2019-07-15"  =
+
+  DOMAIN
+
+    Point = COORD 165000.000 .. 1806900.000 [INTERLIS.m], 23000.000 .. 1984900.000 [INTERLIS.m] ,ROTATION 2 -> 1;
+
+  TOPIC Topic =
+
+    CLASS FirstLevelClass =
+      my_geometry : Model.Point;
+      my_another_geometry : Model.Point;
+    END FirstLevelClass;
+
+    CLASS SecondLevelClass
+    EXTENDS FirstLevelClass =
+      my_geometry (EXTENDED) : MANDATORY Model.Point;
+    END SecondLevelClass;
+
+  END Topic;
+
+END Model.

--- a/test/data/ExtendedAttributes/ExtendedAttributes.xtf
+++ b/test/data/ExtendedAttributes/ExtendedAttributes.xtf
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?><TRANSFER xmlns="http://www.interlis.ch/INTERLIS2.3">
+<HEADERSECTION SENDER="ili2pg-developer-workspace" VERSION="2.3"><MODELS><MODEL NAME="Model" VERSION="2019-07-15" URI="mailto:PC4@localhost"></MODEL></MODELS></HEADERSECTION>
+<DATASECTION>
+<Model.Topic BID="Model.Topic">
+<Model.Topic.FirstLevelClass TID="1"><my_geometry><COORD><C1>994919.860</C1><C2>1001361.737</C2></COORD></my_geometry><my_another_geometry><COORD><C1>995331.491</C1><C2>1001263.590</C2></COORD></my_another_geometry></Model.Topic.FirstLevelClass>
+<Model.Topic.SecondLevelClass TID="2"><my_geometry><COORD><C1>994741.144</C1><C2>1000904.694</C2></COORD></my_geometry><my_another_geometry><COORD><C1>995247.993</C1><C2>1000947.176</C2></COORD></my_another_geometry></Model.Topic.SecondLevelClass>
+</Model.Topic>
+</DATASECTION>
+</TRANSFER>


### PR DESCRIPTION
Fix issues listed below:
- Avoid duplicated geometry fields generation for smart2inheritance when there are extended geometry attributes.

    - Avoid extra table generation when --oneGeomPerTable is used

    - Avoid extra attribute generation when --oneGeomPerTable is not used

- Assign correct attributes cardinality in database for, any type of, extended attributes (takes child cardinality, not parent cardinality) 