### PR TITLE
ili2ora & mssql: remove double quotes for 'filename' (t_ili2db_model)

### DIFF
--- a/src/ch/ehi/ili2db/fromili/TransferFromIli.java
+++ b/src/ch/ehi/ili2db/fromili/TransferFromIli.java
@@ -576,10 +576,6 @@ public class TransferFromIli {
 
 	            // insert entries
 	            String insStmt="INSERT INTO "+sqlName+" ("+DbNames.MODELS_TAB_FILENAME_COL+","+DbNames.MODELS_TAB_ILIVERSION_COL+","+DbNames.MODELS_TAB_MODELNAME_COL+","+DbNames.MODELS_TAB_CONTENT_COL+","+DbNames.MODELS_TAB_IMPORTDATE_COL+") VALUES (?,?,?,?,?)";
-	            if(isMsSqlServer(conn) || isOracle(conn)) {
-	                // 'file' is keyword in sql server and oracle
-	                insStmt="INSERT INTO "+sqlName+" (\""+DbNames.MODELS_TAB_FILENAME_COL+"\","+DbNames.MODELS_TAB_ILIVERSION_COL+","+DbNames.MODELS_TAB_MODELNAME_COL+","+DbNames.MODELS_TAB_CONTENT_COL+","+DbNames.MODELS_TAB_IMPORTDATE_COL+") VALUES (?,?,?,?,?)";
-	            }
 	            EhiLogger.traceBackendCmd(insStmt);
 	            java.sql.PreparedStatement insPrepStmt = conn.prepareStatement(insStmt);
 	            try{


### PR DESCRIPTION
Previously, this column was called 'file', which was a keyword for Oracle and Mssql, but it was renamed 'file name' and now the double-quotes enclosing that column are no longer necessary.

In oracle error below occurs due to the double-quotes:
```
Info: addModels(): INSERT INTO C##ORA.T_ILI2DB_MODEL ("filename",iliversion,modelName,content,importDate) VALUES (?,?,?,?,?) (TransferFromIli.java:583)
failed to insert model
    ch.ehi.ili2db.fromili.TransferFromIli.addModels(TransferFromIli.java:600)
    ch.ehi.ili2db.base.Ili2db.runSchemaImport(Ili2db.java:1274)
    ch.ehi.ili2db.base.Ili2db.run(Ili2db.java:225)
    ch.ehi.ili2db.AbstractMain.domain(AbstractMain.java:548)
    ch.ehi.ili2ora.OraMain.main(OraMain.java:87)
  ORA-00904: "filename": invalid identifier
```