### PR TITLE
Fixed value False for 'inactive' field in enumerations(--createscript #328)

### DIFF
--- a/ili2gpkg/test/java/ch/ehi/ili2gpkg/Enum23Test.java
+++ b/ili2gpkg/test/java/ch/ehi/ili2gpkg/Enum23Test.java
@@ -1,0 +1,12 @@
+package ch.ehi.ili2gpkg;
+
+import ch.ehi.ili2db.AbstractTestSetup;
+
+public class Enum23Test extends ch.ehi.ili2db.Enum23Test {
+    private static final String GPKGFILENAME=TEST_OUT + "Enum23.gpkg";
+    private static final String DBURL="jdbc:sqlite:"+GPKGFILENAME;
+    @Override
+    protected AbstractTestSetup createTestSetup() {
+        return new GpkgTestSetup(GPKGFILENAME,DBURL);
+    }
+}

--- a/ili2mssql/test/java/ch/ehi/ili2mssql/EnumTest23.java
+++ b/ili2mssql/test/java/ch/ehi/ili2mssql/EnumTest23.java
@@ -1,0 +1,17 @@
+package ch.ehi.ili2mssql;
+
+import ch.ehi.ili2db.AbstractTestSetup;
+
+public class EnumTest23 extends ch.ehi.ili2db.Enum23Test {
+    private static final String DBSCHEMA = "Enum23";
+
+    @Override
+    protected AbstractTestSetup createTestSetup() {
+        String dburl=System.getProperty("dburl"); 
+        String dbuser=System.getProperty("dbusr");
+        String dbpwd=System.getProperty("dbpwd");
+        
+        return new MsSqlTestSetup(dburl, dbuser, dbpwd, DBSCHEMA);
+    }
+
+}

--- a/ili2mssql/test/java/ch/ehi/ili2mssql/MsSqlTestSetup.java
+++ b/ili2mssql/test/java/ch/ehi/ili2mssql/MsSqlTestSetup.java
@@ -1,6 +1,5 @@
 package ch.ehi.ili2mssql;
 
-import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -10,6 +9,7 @@ import java.sql.Statement;
 import ch.ehi.ili2db.AbstractTestSetup;
 import ch.ehi.ili2db.base.Ili2db;
 import ch.ehi.ili2db.gui.Config;
+import ch.ehi.ili2mssql.test_utils.TestUtils;
 
 public class MsSqlTestSetup extends AbstractTestSetup {
     private String dburl;
@@ -17,19 +17,12 @@ public class MsSqlTestSetup extends AbstractTestSetup {
     private String dbpwd;
     private String dbschema;
     
-    private String dropSchema;
-    
     public MsSqlTestSetup(String dburl, String dbuser, String dbpwd,String dbschema) {
         super();
         this.dburl=dburl;
         this.dbuser=dbuser;
         this.dbpwd=dbpwd;
         this.dbschema=dbschema;
-        try {
-            dropSchema = this.getScript();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
     }
 
     @Override
@@ -75,9 +68,12 @@ public class MsSqlTestSetup extends AbstractTestSetup {
             try {
                 Statement stmt=jdbcConnection.createStatement();
                 try {
-                    String strStmt = dropSchema.replace("{{{schema}}}", dbschema);
-                    stmt.execute(strStmt);
-                }finally {
+                    String dropScript = TestUtils.getDropScript(dbschema);
+                    stmt.execute(dropScript);
+                } catch(IOException e) {
+                    throw new SQLException("Could not load drop schema script file");
+                }
+                finally {
                     stmt.close();
                     stmt=null;
                 }
@@ -103,20 +99,5 @@ public class MsSqlTestSetup extends AbstractTestSetup {
     @Override
     protected String getSchema() {
         return dbschema;
-    }
-
-    private String getScript() throws java.io.IOException {
-        File file = new File("test/data/MssqlBase/dropSchema.sql");
-        java.io.InputStream is = new java.io.FileInputStream(file.getPath());
-        java.io.BufferedReader buf = new java.io.BufferedReader(new java.io.InputStreamReader(is));
-                
-        String line = buf.readLine();
-        StringBuilder sb = new StringBuilder();
-                
-        while(line != null){
-           sb.append(line).append("\n");
-           line = buf.readLine();
-        }
-        return sb.toString();
     }
 }

--- a/ili2mssql/test/java/ch/ehi/ili2mssql/test_utils/TestUtils.java
+++ b/ili2mssql/test/java/ch/ehi/ili2mssql/test_utils/TestUtils.java
@@ -1,0 +1,26 @@
+package ch.ehi.ili2mssql.test_utils;
+
+import java.io.File;
+
+public class TestUtils {
+    static String dropSchemaScript;
+    
+    static public String getDropScript(String dbschema) throws java.io.IOException {
+        if(dropSchemaScript==null) {
+            File file = new File("test/data/MssqlBase/dropSchema.sql");
+            java.io.InputStream is = new java.io.FileInputStream(file.getPath());
+            java.io.BufferedReader buf = new java.io.BufferedReader(new java.io.InputStreamReader(is));
+                    
+            String line = buf.readLine();
+            StringBuilder sb = new StringBuilder();
+                    
+            while(line != null){
+               sb.append(line).append("\n");
+               line = buf.readLine();
+            }
+            buf.close();
+            dropSchemaScript = sb.toString();
+        }
+        return dropSchemaScript.replace("{{{schema}}}", dbschema);
+    }
+}

--- a/ili2pg/test/java/ch/ehi/ili2pg/Enum23Test.java
+++ b/ili2pg/test/java/ch/ehi/ili2pg/Enum23Test.java
@@ -1,4 +1,4 @@
-package ch.ehi.ili2db;
+package ch.ehi.ili2pg;
 
 import java.io.File;
 import java.sql.Connection;
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import org.junit.Assert;
 import org.junit.Test;
 
+import ch.ehi.ili2db.AbstractTestSetup;
 import ch.ehi.ili2db.base.DbNames;
 import ch.ehi.ili2db.base.Ili2db;
 import ch.ehi.ili2db.gui.Config;
@@ -25,14 +26,22 @@ import ch.interlis.iox.StartBasketEvent;
 import ch.interlis.iox.StartTransferEvent;
 
 //-Ddburl=jdbc:postgresql:dbname -Ddbusr=usrname -Ddbpwd=1234
-public class Enum23Test {
+public class Enum23Test extends ch.ehi.ili2db.Enum23Test{
 	private static final String DBSCHEMA = "Enum23";
-	String dburl=System.getProperty("dburl"); 
-	String dbuser=System.getProperty("dbusr");
-	String dbpwd=System.getProperty("dbpwd"); 
+    String dburl;
+    String dbuser;
+    String dbpwd; 
 	Connection jdbcConnection=null;
 	Statement stmt=null;
-	
+
+    @Override
+    protected AbstractTestSetup createTestSetup() {
+        dburl=System.getProperty("dburl"); 
+        dbuser=System.getProperty("dbusr");
+        dbpwd=System.getProperty("dbpwd"); 
+        return new PgTestSetup(dburl,dbuser,dbpwd,DBSCHEMA);
+    }
+
 	public Config initConfig(String xtfFilename,String dbschema,String logfile) {
 		Config config=new Config();
 		new ch.ehi.ili2pg.PgMain().initConfig(config);
@@ -97,214 +106,7 @@ public class Enum23Test {
 			}
 		}	
 	}
-    @Test
-    public void createScriptFromIliFkTable() throws Exception
-    {
-        Connection jdbcConnection=null;
-        try{
-            File data=new File("test/data/Enum23/Enum23b.ili");
-            File outfile=new File(data.getPath()+"-out.sql");
-            Config config=new Config();
-            new ch.ehi.ili2pg.PgMain().initConfig(config);
-            config.setLogfile(data.getPath()+".log");
-            config.setXtffile(data.getPath());
-            config.setFunction(Config.FC_SCRIPT);
-            config.setCreateFk(Config.CREATE_FK_YES);
-            config.setDbschema(DBSCHEMA);
-            config.setCreateNumChecks(true);
-            config.setTidHandling(Config.TID_HANDLING_PROPERTY);
-            config.setBasketHandling(Config.BASKET_HANDLING_READWRITE);
-            config.setCreateMetaInfo(true);
-            config.setCreateEnumDefs(Config.CREATE_ENUM_DEFS_MULTI_WITH_ID);
-            config.setCatalogueRefTrafo(null);
-            config.setMultiSurfaceTrafo(null);
-            config.setMultilingualTrafo(null);
-            config.setInheritanceTrafo(null);
-            config.setCreatescript(outfile.getPath());
-            Ili2db.run(config,null);
-            
-            // verify generated script
-            {
-                Class driverClass = Class.forName("org.postgresql.Driver");
-                jdbcConnection = DriverManager.getConnection(
-                        dburl, dbuser, dbpwd);
-                jdbcConnection.setAutoCommit(false);
-                stmt=jdbcConnection.createStatement();          
-                stmt.execute("DROP SCHEMA IF EXISTS "+DBSCHEMA+" CASCADE");
-                stmt.close();
-                stmt=null;
-                
-                // execute generated script
-                DbUtility.executeSqlScript(jdbcConnection, new java.io.FileReader(outfile));
 
-                jdbcConnection.commit();
-                jdbcConnection.close();
-                jdbcConnection=null;
-                
-                {
-                    // rum import without schema generation
-                    data=new File("test/data/Enum23/Enum23b.xtf");
-                    config.setXtffile(data.getPath());
-                    config.setDburl(dburl);
-                    config.setDbusr(dbuser);
-                    config.setDbpwd(dbpwd);
-                    config.setDbschema(DBSCHEMA);
-                    config.setFunction(Config.FC_IMPORT);
-                    config.setDoImplicitSchemaImport(false);
-                    config.setCreatescript(null);
-                    Ili2db.readSettingsFromDb(config);
-                    Ili2db.run(config,null);
-                    
-                }
-                
-            }
-            
-        }finally{
-            if(jdbcConnection!=null){
-                jdbcConnection.close();
-                jdbcConnection=null;
-            }
-        }   
-    }
-    @Test
-    public void createScriptFromIliSingleTable() throws Exception
-    {
-        Connection jdbcConnection=null;
-        try{
-            File data=new File("test/data/Enum23/Enum23b.ili");
-            File outfile=new File(data.getPath()+"-out.sql");
-            Config config=new Config();
-            new ch.ehi.ili2pg.PgMain().initConfig(config);
-            config.setLogfile(data.getPath()+".log");
-            config.setXtffile(data.getPath());
-            config.setFunction(Config.FC_SCRIPT);
-            config.setCreateFk(Config.CREATE_FK_YES);
-            config.setDbschema(DBSCHEMA);
-            config.setCreateNumChecks(true);
-            config.setTidHandling(Config.TID_HANDLING_PROPERTY);
-            config.setBasketHandling(Config.BASKET_HANDLING_READWRITE);
-            config.setCreateMetaInfo(true);
-            config.setCreateEnumDefs(Config.CREATE_ENUM_DEFS_SINGLE);
-            config.setCatalogueRefTrafo(null);
-            config.setMultiSurfaceTrafo(null);
-            config.setMultilingualTrafo(null);
-            config.setInheritanceTrafo(null);
-            config.setCreatescript(outfile.getPath());
-            Ili2db.run(config,null);
-            
-            // verify generated script
-            {
-                Class driverClass = Class.forName("org.postgresql.Driver");
-                jdbcConnection = DriverManager.getConnection(
-                        dburl, dbuser, dbpwd);
-                jdbcConnection.setAutoCommit(false);
-                stmt=jdbcConnection.createStatement();          
-                stmt.execute("DROP SCHEMA IF EXISTS "+DBSCHEMA+" CASCADE");
-                stmt.close();
-                stmt=null;
-                
-                // execute generated script
-                DbUtility.executeSqlScript(jdbcConnection, new java.io.FileReader(outfile));
-
-                jdbcConnection.commit();
-                jdbcConnection.close();
-                jdbcConnection=null;
-                
-                {
-                    // rum import without schema generation
-                    data=new File("test/data/Enum23/Enum23b.xtf");
-                    config.setXtffile(data.getPath());
-                    config.setDburl(dburl);
-                    config.setDbusr(dbuser);
-                    config.setDbpwd(dbpwd);
-                    config.setDbschema(DBSCHEMA);
-                    config.setFunction(Config.FC_IMPORT);
-                    config.setDoImplicitSchemaImport(false);
-                    config.setCreatescript(null);
-                    Ili2db.readSettingsFromDb(config);
-                    Ili2db.run(config,null);
-                    
-                }
-                
-            }
-            
-        }finally{
-            if(jdbcConnection!=null){
-                jdbcConnection.close();
-                jdbcConnection=null;
-            }
-        }   
-    }
-    @Test
-    public void createScriptFromIliMultiTable() throws Exception
-    {
-        Connection jdbcConnection=null;
-        try{
-            File data=new File("test/data/Enum23/Enum23b.ili");
-            File outfile=new File(data.getPath()+"-out.sql");
-            Config config=new Config();
-            new ch.ehi.ili2pg.PgMain().initConfig(config);
-            config.setLogfile(data.getPath()+".log");
-            config.setXtffile(data.getPath());
-            config.setFunction(Config.FC_SCRIPT);
-            config.setCreateFk(Config.CREATE_FK_YES);
-            config.setDbschema(DBSCHEMA);
-            config.setCreateNumChecks(true);
-            config.setTidHandling(Config.TID_HANDLING_PROPERTY);
-            config.setBasketHandling(Config.BASKET_HANDLING_READWRITE);
-            config.setCreateMetaInfo(true);
-            config.setCreateEnumDefs(Config.CREATE_ENUM_DEFS_MULTI);
-            config.setCatalogueRefTrafo(null);
-            config.setMultiSurfaceTrafo(null);
-            config.setMultilingualTrafo(null);
-            config.setInheritanceTrafo(null);
-            config.setCreatescript(outfile.getPath());
-            Ili2db.run(config,null);
-            
-            // verify generated script
-            {
-                Class driverClass = Class.forName("org.postgresql.Driver");
-                jdbcConnection = DriverManager.getConnection(
-                        dburl, dbuser, dbpwd);
-                jdbcConnection.setAutoCommit(false);
-                stmt=jdbcConnection.createStatement();          
-                stmt.execute("DROP SCHEMA IF EXISTS "+DBSCHEMA+" CASCADE");
-                stmt.close();
-                stmt=null;
-                
-                // execute generated script
-                DbUtility.executeSqlScript(jdbcConnection, new java.io.FileReader(outfile));
-
-                jdbcConnection.commit();
-                jdbcConnection.close();
-                jdbcConnection=null;
-                
-                {
-                    // rum import without schema generation
-                    data=new File("test/data/Enum23/Enum23b.xtf");
-                    config.setXtffile(data.getPath());
-                    config.setDburl(dburl);
-                    config.setDbusr(dbuser);
-                    config.setDbpwd(dbpwd);
-                    config.setDbschema(DBSCHEMA);
-                    config.setFunction(Config.FC_IMPORT);
-                    config.setDoImplicitSchemaImport(false);
-                    config.setCreatescript(null);
-                    Ili2db.readSettingsFromDb(config);
-                    Ili2db.run(config,null);
-                    
-                }
-                
-            }
-            
-        }finally{
-            if(jdbcConnection!=null){
-                jdbcConnection.close();
-                jdbcConnection=null;
-            }
-        }   
-    }
-	
 	@Test
 	public void importIliWithBeautify() throws Exception
 	{

--- a/src/ch/ehi/ili2db/fromili/TransferFromIli.java
+++ b/src/ch/ehi/ili2db/fromili/TransferFromIli.java
@@ -1644,7 +1644,7 @@ public class TransferFromIli {
                 }else{
                     insStmt.append(","+ Ili2db.quoteSqlStringValue(recConv.beautifyEnumDispName(eleName))); 
                 }
-                insStmt.append(",FALSE");  // inactive
+                insStmt.append(",'0'");  // inactive
                 String description = eleElement.getDocumentation();
                 insStmt.append(","+ Ili2db.quoteSqlStringValue(description));
 

--- a/test/java/ch/ehi/ili2db/Enum23Test.java
+++ b/test/java/ch/ehi/ili2db/Enum23Test.java
@@ -1,0 +1,184 @@
+package ch.ehi.ili2db;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.Statement;
+
+import org.junit.Test;
+
+import ch.ehi.ili2db.base.Ili2db;
+import ch.ehi.ili2db.gui.Config;
+import ch.ehi.sqlgen.DbUtility;
+
+public abstract class Enum23Test {
+    protected static final String TEST_OUT="test/data/Enum23/";
+    protected AbstractTestSetup setup=createTestSetup();
+    protected abstract AbstractTestSetup createTestSetup() ;
+
+    Statement stmt=null;
+    @Test
+    public void createScriptFromIliFkTable() throws Exception
+    {
+        Connection jdbcConnection=null;
+        try{
+            File data=new File(TEST_OUT,"Enum23b.ili");
+            File outfile=new File(data.getPath()+"-out.sql");
+            Config config=setup.initConfig(data.getPath(),data.getPath()+".log");
+            config.setFunction(Config.FC_SCRIPT);
+            config.setCreateFk(Config.CREATE_FK_YES);
+            config.setCreateNumChecks(true);
+            config.setTidHandling(Config.TID_HANDLING_PROPERTY);
+            config.setBasketHandling(Config.BASKET_HANDLING_READWRITE);
+            config.setCreateMetaInfo(true);
+            config.setCreateEnumDefs(Config.CREATE_ENUM_DEFS_MULTI_WITH_ID);
+            config.setCatalogueRefTrafo(null);
+            config.setMultiSurfaceTrafo(null);
+            config.setMultilingualTrafo(null);
+            config.setInheritanceTrafo(null);
+            config.setCreatescript(outfile.getPath());
+            Ili2db.run(config,null);
+            
+            // verify generated script
+            {
+                setup.resetDb();
+                jdbcConnection=setup.createDbSchema();
+                jdbcConnection.setAutoCommit(false);
+                // execute generated script
+                DbUtility.executeSqlScript(jdbcConnection, new java.io.FileReader(outfile));
+
+                jdbcConnection.commit();
+                jdbcConnection.close();
+                jdbcConnection=null;
+                
+                {
+                    // rum import without schema generation
+                    data=new File(TEST_OUT,"Enum23b.xtf");
+                    config.setXtffile(data.getPath());
+                    config.setFunction(Config.FC_IMPORT);
+                    config.setDoImplicitSchemaImport(false);
+                    config.setCreatescript(null);
+                    Ili2db.readSettingsFromDb(config);
+                    Ili2db.run(config,null);
+                    
+                }
+                
+            }
+            
+        }finally{
+            if(jdbcConnection!=null){
+                jdbcConnection.close();
+                jdbcConnection=null;
+            }
+        }   
+    }
+    @Test
+    public void createScriptFromIliSingleTable() throws Exception
+    {
+        Connection jdbcConnection=null;
+        try{
+            File data=new File(TEST_OUT,"Enum23b.ili");
+            File outfile=new File(data.getPath()+"-out.sql");
+            Config config=setup.initConfig(data.getPath(),data.getPath()+".log");
+            config.setFunction(Config.FC_SCRIPT);
+            config.setCreateFk(Config.CREATE_FK_YES);
+            config.setCreateNumChecks(true);
+            config.setTidHandling(Config.TID_HANDLING_PROPERTY);
+            config.setBasketHandling(Config.BASKET_HANDLING_READWRITE);
+            config.setCreateMetaInfo(true);
+            config.setCreateEnumDefs(Config.CREATE_ENUM_DEFS_SINGLE);
+            config.setCatalogueRefTrafo(null);
+            config.setMultiSurfaceTrafo(null);
+            config.setMultilingualTrafo(null);
+            config.setInheritanceTrafo(null);
+            config.setCreatescript(outfile.getPath());
+            Ili2db.run(config,null);
+            
+            // verify generated script
+            {
+                setup.resetDb();
+                jdbcConnection=setup.createDbSchema();
+                jdbcConnection.setAutoCommit(false);
+                // execute generated script
+                DbUtility.executeSqlScript(jdbcConnection, new java.io.FileReader(outfile));
+
+                jdbcConnection.commit();
+                jdbcConnection.close();
+                jdbcConnection=null;
+                
+                {
+                    // rum import without schema generation
+                    data=new File(TEST_OUT,"Enum23b.xtf");
+                    config.setXtffile(data.getPath());
+                    config.setFunction(Config.FC_IMPORT);
+                    config.setDoImplicitSchemaImport(false);
+                    config.setCreatescript(null);
+                    Ili2db.readSettingsFromDb(config);
+                    Ili2db.run(config,null);
+                    
+                }
+                
+            }
+            
+        }finally{
+            if(jdbcConnection!=null){
+                jdbcConnection.close();
+                jdbcConnection=null;
+            }
+        }   
+    }
+    @Test
+    public void createScriptFromIliMultiTable() throws Exception
+    {
+        Connection jdbcConnection=null;
+        try{
+            File data=new File(TEST_OUT,"Enum23b.ili");
+            File outfile=new File(data.getPath()+"-out.sql");
+            Config config=setup.initConfig(data.getPath(),data.getPath()+".log");
+            config.setFunction(Config.FC_SCRIPT);
+            config.setCreateFk(Config.CREATE_FK_YES);
+            config.setCreateNumChecks(true);
+            config.setTidHandling(Config.TID_HANDLING_PROPERTY);
+            config.setBasketHandling(Config.BASKET_HANDLING_READWRITE);
+            config.setCreateMetaInfo(true);
+            config.setCreateEnumDefs(Config.CREATE_ENUM_DEFS_MULTI);
+            config.setCatalogueRefTrafo(null);
+            config.setMultiSurfaceTrafo(null);
+            config.setMultilingualTrafo(null);
+            config.setInheritanceTrafo(null);
+            config.setCreatescript(outfile.getPath());
+            Ili2db.run(config,null);
+            
+            // verify generated script
+            {
+                setup.resetDb();
+                jdbcConnection=setup.createDbSchema();
+                jdbcConnection.setAutoCommit(false);
+                // execute generated script
+                DbUtility.executeSqlScript(jdbcConnection, new java.io.FileReader(outfile));
+
+                jdbcConnection.commit();
+                jdbcConnection.close();
+                jdbcConnection=null;
+                
+                {
+                    // rum import without schema generation
+                    data=new File(TEST_OUT,"Enum23b.xtf");
+                    config.setXtffile(data.getPath());
+                    config.setFunction(Config.FC_IMPORT);
+                    config.setDoImplicitSchemaImport(false);
+                    config.setCreatescript(null);
+                    Ili2db.readSettingsFromDb(config);
+                    Ili2db.run(config,null);
+                    
+                }
+                
+            }
+            
+        }finally{
+            if(jdbcConnection!=null){
+                jdbcConnection.close();
+                jdbcConnection=null;
+            }
+        }   
+    }
+}


### PR DESCRIPTION
This PR changes the 'inactive' field value in enumerations from **False** to **'0'**.

About tests:

- 'Create script' tests in Enum23Test were moved to a new abstract class Enum23Test to reuse that code.
- Added the classes Enum23Test for SQL Server and Geopackage that inherit from that abstract class.
- Moved the original class Enum23Test from ili2db package to ili2pg.