### PR TITLE
[ili2duckdb] fix missing install spatial

### DIFF
--- a/ili2duckdb/src/ch/ehi/ili2duckdb/DuckDBMapping.java
+++ b/ili2duckdb/src/ch/ehi/ili2duckdb/DuckDBMapping.java
@@ -26,7 +26,7 @@ public class DuckDBMapping extends AbstractJdbcMapping {
     }
     @Override
     public void postConnect(Connection conn, Config config) {
-        if(isNewFile!=null && isNewFile){
+        if(isNewFile!=null) {
             Statement dbstmt = null;
             try{
                 try{
@@ -45,24 +45,7 @@ public class DuckDBMapping extends AbstractJdbcMapping {
                 }
             }catch(SQLException ex){
                 throw new IllegalStateException(ex);
-            }
-        } else if (isNewFile != null && !isNewFile) {
-            Statement dbstmt = null;
-            try{
-                try{
-                    String line="LOAD spatial;";
-                    dbstmt = conn.createStatement();
-                    EhiLogger.traceBackendCmd(line);
-                    dbstmt.execute(line);
-                }finally{
-                    if(dbstmt!=null) {
-                        dbstmt.close();
-                        dbstmt=null;
-                    }
-                }
-            }catch(SQLException ex){
-                throw new IllegalStateException(ex);
-            }
+            }    
         }
     }
     @Override


### PR DESCRIPTION
Die Unterscheidung, dass es bei einer existierenden DuckDB-Datei kein `INSTALL spatial` benötigt, ist falsch. Wenn auf dem Rechner noch nie DuckDB mit Spatial lief, fehlt die Extension auf dem Rechner (liegt irgendwo in einem versteckten Home-Subordner). Und wenn nun auf dem Rechner z.B. ein Export aus einer DuckDB gemacht wird, wurde INSTALL spatial nicht ausgeführt.