### PR TITLE
DuckDB Update 1.5.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -384,8 +384,8 @@ dependencies {
 	//ili2h2gisImplementation group: 'org.locationtech.jts', name: 'jts-core', version: '1.17.0'
 	//compileOnly group: 'org.locationtech.jts', name: 'jts-core', version: '1.17.0'
 	
-	ili2duckdbImplementation group: 'org.duckdb', name:'duckdb_jdbc',version: '1.1.3'
-	compileOnly group: 'org.duckdb', name:'duckdb_jdbc',version: '1.1.3' // add as compileOnly, so that eclipse sees it
+	ili2duckdbImplementation group: 'org.duckdb', name:'duckdb_jdbc',version: '1.5.2.1'
+	compileOnly group: 'org.duckdb', name:'duckdb_jdbc',version: '1.5.2.1' // add as compileOnly, so that eclipse sees it
 	ili2fgdbImplementation group: 'ch.ehi', name: 'fgdb4j', version: "1.1.1"
 	ili2fgdbImplementation "antlr:antlr:2.7.7" 	
 	compileOnly group: 'ch.ehi', name: 'fgdb4j', version: "1.1.1" // add as compileOnly, so that eclipse sees it

--- a/ili2duckdb/src/ch/ehi/ili2duckdb/DuckDBColumnConverter.java
+++ b/ili2duckdb/src/ch/ehi/ili2duckdb/DuckDBColumnConverter.java
@@ -130,44 +130,33 @@ public class DuckDBColumnConverter extends AbstractWKBColumnConverter {
 		return sqlColName;
 	}
 
-	// ST_AsWKB returns wkt string for clients that don't know how to handle
-	// it natively: https://github.com/duckdb/duckdb-spatial/issues/469
-	// We force to return a blob which will transformed into a byte array
-	// later.
 	@Override
 	public String getSelectValueWrapperCoord(String dbNativeValue) {
-		return "ST_AsWKB("+dbNativeValue+")::blob";
+		return "ST_AsWKB("+dbNativeValue+")";
 	}
 	@Override
 	public String getSelectValueWrapperMultiCoord(String dbNativeValue) {
-		return "ST_AsWKB("+dbNativeValue+")::blob";
+		return "ST_AsWKB("+dbNativeValue+")";
 	}
 	@Override
 	public String getSelectValueWrapperPolyline(String dbNativeValue) {
-		return "ST_AsWKB("+dbNativeValue+")::blob";
+		return "ST_AsWKB("+dbNativeValue+")";
 	}
 	@Override
 	public String getSelectValueWrapperMultiPolyline(String dbNativeValue) {
-		return "ST_AsWKB("+dbNativeValue+")::blob";
+		return "ST_AsWKB("+dbNativeValue+")";
 	}
 	@Override
 	public String getSelectValueWrapperSurface(String dbNativeValue) {
-		return "ST_AsWKB("+dbNativeValue+")::blob";
+		return "ST_AsWKB("+dbNativeValue+")";
 	}
 	@Override
 	public String getSelectValueWrapperMultiSurface(String dbNativeValue) {
-		return "ST_AsWKB("+dbNativeValue+")::blob";
+		return "ST_AsWKB("+dbNativeValue+")";
 	}
 	@Override
 	public String getSelectValueWrapperArray(String dbColName) {
 		return dbColName;
-	}
-	// DuckDB has a uuid data type but the PreparedStatement class does
-	// not support uuid in the setObject method.
-	public Object fromIomUuid(String uuid) 
-			throws java.sql.SQLException, ConverterException
-	{
-		return uuid;
 	}
 	@Override
 	public Object fromIomXml(String xml) 
@@ -569,7 +558,7 @@ public class DuckDBColumnConverter extends AbstractWKBColumnConverter {
     @Override
     public void setTime(PreparedStatement ps, int valuei, Time time)
             throws SQLException {
-        ps.setObject(valuei, time.toString());
+        ps.setTime(valuei, time);
     }	
 	@Override
 	public String[] toIomArray(ch.interlis.ili2c.metamodel.AttributeDef attr,Object sqlArray,Class<? extends DbColumn> dbColHint) throws SQLException, ConverterException {

--- a/ili2duckdb/test/java/ch/ehi/ili2duckdb/impl/Datatypes23Test.java
+++ b/ili2duckdb/test/java/ch/ehi/ili2duckdb/impl/Datatypes23Test.java
@@ -376,7 +376,7 @@ public abstract class Datatypes23Test {
                 ResultSet rs=stmt.getResultSet();
                 Assert.assertTrue(rs.next());
                 Blob blob = (Blob) rs.getObject("binbox");
-                int blobLength = (int) blob.length();  
+                int blobLength = (int) blob.length();
                 byte[] bytes = blob.getBytes(1, blobLength);
                 Assert.assertFalse(rs.wasNull());
                 String wkbText=Base64.encodeBytes(bytes);
@@ -467,12 +467,9 @@ public abstract class Datatypes23Test {
                 Assert.assertTrue(stmt.execute(stmtT));
                 ResultSet rs=stmt.getResultSet();
                 Assert.assertTrue(rs.next());
-                Blob blob = (Blob) rs.getObject("binbox");
-                int blobLength = (int) blob.length();  
-                byte[] bytes = blob.getBytes(1, blobLength);
+                String bytes = rs.getString("binbox");
                 Assert.assertFalse(rs.wasNull());
-                String wkbText=Base64.encodeBytes(bytes);
-                Assert.assertEquals("AAAA", wkbText);
+                Assert.assertEquals("AAAA", bytes);
             }
         }catch(SQLException e) {
             throw new IoxException(e);


### PR DESCRIPTION
- Der JDBC-Treiber wurde auf 1.5.2.1 (von 1.1.3) upgedatet.
- Rückwärtskompatibilität ist garantiert. Vorwärtskompatibilität ist "best effort".
- Codevereinfachung im Column Converter dank neuerem JDBC-Treiber.
